### PR TITLE
Fix: Restrict book removal requests to admin's assigned locations

### DIFF
--- a/workers/books/index.ts
+++ b/workers/books/index.ts
@@ -558,14 +558,15 @@ export async function createBookRemovalRequest(request: Request, userId: string,
 export async function getBookRemovalRequests(userId: string, env: Env, corsHeaders: Record<string, string>) {
 
   try {
-    // Check if user is admin
+    // Check user permissions
     const isAdmin = await isUserAdmin(userId, env);
+    const isSuperAdmin = await isUserSuperAdmin(userId, env);
     
     let requestsStmt;
     let bindings: any[];
 
-    if (isAdmin) {
-      // Admins can see all requests
+    if (isSuperAdmin) {
+      // Super admins can see all requests
       requestsStmt = env.DB.prepare(`
         SELECT rr.*, 
                b.title as book_title, 
@@ -584,6 +585,33 @@ export async function getBookRemovalRequests(userId: string, env: Env, corsHeade
         ORDER BY rr.created_at DESC
       `);
       bindings = [];
+    } else if (isAdmin) {
+      // Regular admins can only see requests from their assigned locations
+      requestsStmt = env.DB.prepare(`
+        SELECT rr.*, 
+               b.title as book_title, 
+               b.authors as book_authors,
+               b.isbn as book_isbn,
+               l.name as location_name,
+               u_requester.first_name as requester_name,
+               u_requester.email as requester_email,
+               u_reviewer.first_name as reviewer_name
+        FROM book_removal_requests rr
+        LEFT JOIN books b ON rr.book_id = b.id
+        LEFT JOIN shelves s ON b.shelf_id = s.id
+        LEFT JOIN locations l ON s.location_id = l.id
+        LEFT JOIN users u_requester ON rr.requester_id = u_requester.id
+        LEFT JOIN users u_reviewer ON rr.reviewed_by = u_reviewer.id
+        WHERE l.id IN (
+          SELECT location_id FROM (
+            SELECT id as location_id FROM locations WHERE owner_id = ?
+            UNION
+            SELECT location_id FROM location_members WHERE user_id = ?
+          )
+        )
+        ORDER BY rr.created_at DESC
+      `);
+      bindings = [userId, userId];
     } else {
       // Regular users can only see their own requests
       requestsStmt = env.DB.prepare(`


### PR DESCRIPTION
## Summary
- Fixes issue where regular admins could see book removal requests from all locations
- Super admins continue to see all removal requests globally  
- Regular admins now only see requests from locations they own or are assigned to
- Regular users continue to see only their own requests

## Changes Made
- Modified `getBookRemovalRequests` function in `workers/books/index.ts`
- Added proper permission differentiation between super admins and regular admins
- Implemented location-scoped filtering using SQL UNION query
- Added `isUserSuperAdmin` check alongside existing `isUserAdmin` check

## Test Plan
- [x] Code compiles successfully with TypeScript
- [x] All existing linting rules pass
- [x] Build process completes without errors
- [x] Permission logic correctly differentiates between user types
- [x] SQL query properly filters by location ownership and membership

## Security Impact
- Prevents cross-location data leakage between admin users
- Maintains super admin's global oversight capability
- Preserves existing security model for regular users

Fixes #5