### PR TITLE
feat: Allow regular admins to view users from their assigned locations

### DIFF
--- a/workers/admin-extended/index.ts
+++ b/workers/admin-extended/index.ts
@@ -239,29 +239,81 @@ export async function getAdminAnalytics(userId: string, env: Env, corsHeaders: R
 }
 
 export async function getAdminUsers(userId: string, env: Env, corsHeaders: Record<string, string>) {
-  // Check if user is super admin (global user management is super admin only)
-  if (!(await isUserSuperAdmin(userId, env))) {
-    return new Response(JSON.stringify({ error: 'Super admin privileges required' }), {
+  // Check if user is at least admin
+  if (!(await isUserAdmin(userId, env))) {
+    return new Response(JSON.stringify({ error: 'Admin privileges required' }), {
       status: 403,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }
 
+  const isSuperAdmin = await isUserSuperAdmin(userId, env);
+
   try {
-    // Get all users with activity stats
-    const users = await env.DB.prepare(`
-      SELECT u.id, u.email, u.first_name, u.last_name, u.auth_provider, 
-             u.email_verified, u.user_role, u.created_at,
-             COUNT(DISTINCT b.id) as books_added,
-             COUNT(DISTINCT COALESCE(lm.location_id, l.id)) as locations_joined,
-             MAX(b.created_at) as last_book_added
-      FROM users u
-      LEFT JOIN books b ON u.id = b.added_by
-      LEFT JOIN location_members lm ON u.id = lm.user_id
-      LEFT JOIN locations l ON u.id = l.owner_id
-      GROUP BY u.id
-      ORDER BY u.created_at DESC
-    `).all();
+    let users;
+    
+    if (isSuperAdmin) {
+      // Super admins can see all users globally
+      users = await env.DB.prepare(`
+        SELECT u.id, u.email, u.first_name, u.last_name, u.auth_provider, 
+               u.email_verified, u.user_role, u.created_at,
+               COUNT(DISTINCT b.id) as books_added,
+               COUNT(DISTINCT COALESCE(lm.location_id, l.id)) as locations_joined,
+               MAX(b.created_at) as last_book_added
+        FROM users u
+        LEFT JOIN books b ON u.id = b.added_by
+        LEFT JOIN location_members lm ON u.id = lm.user_id
+        LEFT JOIN locations l ON u.id = l.owner_id
+        GROUP BY u.id
+        ORDER BY u.created_at DESC
+      `).all();
+    } else {
+      // Regular admins can only see users from their assigned locations
+      users = await env.DB.prepare(`
+        SELECT DISTINCT u.id, u.email, u.first_name, u.last_name, u.auth_provider, 
+               u.email_verified, u.user_role, u.created_at,
+               COUNT(DISTINCT b.id) as books_added,
+               COUNT(DISTINCT COALESCE(lm_user.location_id, l_user.id)) as locations_joined,
+               MAX(b.created_at) as last_book_added
+        FROM users u
+        LEFT JOIN books b ON u.id = b.added_by
+        LEFT JOIN location_members lm_user ON u.id = lm_user.user_id
+        LEFT JOIN locations l_user ON u.id = l_user.owner_id
+        WHERE u.id IN (
+          SELECT DISTINCT user_id FROM (
+            -- Users who are members of locations owned by this admin
+            SELECT lm.user_id 
+            FROM location_members lm
+            INNER JOIN locations l ON lm.location_id = l.id
+            WHERE l.owner_id = ?
+            
+            UNION
+            
+            -- Users who are members of locations this admin is assigned to
+            SELECT lm.user_id 
+            FROM location_members lm
+            WHERE lm.location_id IN (
+              SELECT location_id FROM location_members WHERE user_id = ?
+            )
+            
+            UNION
+            
+            -- Users who own locations this admin is assigned to
+            SELECT l.owner_id as user_id
+            FROM locations l
+            INNER JOIN location_members lm ON l.id = lm.location_id
+            WHERE lm.user_id = ?
+            
+            UNION
+            
+            -- Include the admin themselves
+            SELECT ? as user_id
+          )
+        )
+        GROUP BY u.id
+        ORDER BY u.created_at DESC
+      `).bind(userId, userId, userId, userId).all();
+    }
 
     return new Response(JSON.stringify(users.results), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Enables regular admins to view users from locations they own or are assigned to
- Super admins continue to see all users globally (unchanged)
- Implements comprehensive location-scoped user filtering for regular admins

## Changes Made
- Modified `getAdminUsers` function in `workers/admin-extended/index.ts`
- Changed permission check from super admin only to any admin
- Added location-scoped filtering logic for regular admins using SQL UNION
- Maintains existing super admin behavior for global user management

## User Visibility for Regular Admins
Regular admins can now see:
- ✅ Users who are members of locations they own
- ✅ Users who are members of locations they are assigned to  
- ✅ Users who own locations they are assigned to
- ✅ Themselves (always included)

## Test Plan
- [x] Code compiles successfully with TypeScript
- [x] All existing linting rules pass
- [x] Build process completes without errors
- [x] Permission logic correctly differentiates between super admins and regular admins
- [x] SQL query efficiently filters users by location relationships

## Security Impact
- Maintains location-scoped access control for regular admins
- Preserves super admin's global oversight capability
- No cross-location data leakage outside of assigned permissions

## Backward Compatibility
- ✅ Super admin functionality unchanged (global user access)
- ✅ Existing API contract maintained
- ✅ Frontend components will work without modification

Fixes #2