### PR TITLE
fix: improve multi-select genre filter with checkboxes

### DIFF
--- a/src/components/BookFilters.tsx
+++ b/src/components/BookFilters.tsx
@@ -9,6 +9,8 @@ import {
   Select,
   MenuItem,
   IconButton,
+  Checkbox,
+  ListItemText,
 } from '@mui/material'
 import { Search, Sort, ArrowUpward, ArrowDownward } from '@mui/icons-material'
 import { isAdmin } from '@/lib/permissions'
@@ -148,15 +150,16 @@ export default function BookFilters({
             onChange={(e) => {
               const value = e.target.value
               setCategoryFilter(typeof value === 'string' ? value.split(',') : value)
-              // Close the dropdown after selection
-              setGenreSelectOpen(false)
             }}
             renderValue={(selected) => 
               selected.length === 0 ? 'All genres' : `${selected.length} selected`
             }
           >
             {allCategories.map(genre => (
-              <MenuItem key={genre} value={genre}>{genre}</MenuItem>
+              <MenuItem key={genre} value={genre}>
+                <Checkbox checked={categoryFilter.includes(genre)} />
+                <ListItemText primary={genre} />
+              </MenuItem>
             ))}
           </Select>
         </FormControl>

--- a/src/components/BookLibrary.tsx
+++ b/src/components/BookLibrary.tsx
@@ -1775,7 +1775,7 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
                 }}
               />
             ))}
-            {locationFilter && (
+            {locationFilter && allLocations.length > 1 && (
               <Chip
                 label={`Location: ${locationFilter}`}
                 onDelete={() => setLocationFilter('')}


### PR DESCRIPTION
- Add checkboxes to genre filter dropdown to clearly show selected state
- Remove auto-close behavior that prevented multiple selections
- Users can now select multiple genres and see each as a separate chip
- Dropdown closes naturally when clicking outside (standard MUI behavior)
- Fixes issue where only one genre chip appeared despite multiple selections