### PR TITLE
fix: prevent unnecessary content refreshes on tab focus changes

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## July 14, 2025 - Unnecessary Content Refresh Prevention System Implementation
+
+### Complete Refresh Prevention System - GitHub Issue #50 RESOLVED!
+- **FIXED**: Unnecessary content refreshes when switching tabs/windows and returning to the application
+- **IMPLEMENTED**: Smart state management preventing data reload when app state hasn't changed
+- **ADDED**: Manual refresh functionality with refresh button in library header
+- **ENHANCED**: BookLibrary component with dataLoaded state flag to track loading status
+- **RESOLVED**: useEffect dependency issue causing loadUserData() to trigger on every session object change
+- **CREATED**: Proper state lifecycle management preventing multiple API calls during normal navigation
+- **MAINTAINED**: Existing functionality while eliminating unnecessary API requests and improving performance
+- **VERIFIED**: Solution tested with screenshot automation and build verification
+
+### Refresh Prevention Technical Implementation
+- **MODIFIED**: BookLibrary.tsx useEffect hook to only load data when session exists and data hasn't been loaded
+- **ADDED**: dataLoaded and isRefreshing state variables for proper loading state management
+- **IMPLEMENTED**: handleManualRefresh function providing user-controlled refresh capability
+- **ENHANCED**: Component lifecycle to reset dataLoaded flag when session becomes null
+- **FOLLOWED**: Existing pattern from AppLayout.tsx which already used dataLoadedRef for similar prevention
+- **MAINTAINED**: All existing functionality while preventing unnecessary refreshes on focus/visibility changes
+
+### User Experience Improvements
+- **ELIMINATED**: Unnecessary API calls when switching between browser tabs or OS windows
+- **PRESERVED**: Automatic data loading when users first visit the library page
+- **ADDED**: Refresh button with loading state for manual content refresh when needed
+- **IMPROVED**: Application performance by reducing redundant network requests
+- **MAINTAINED**: Real-time updates when actual state changes occur (new books added, status changes)
+
 ## July 14, 2025 - Book Cover Selection Feature Implementation
 
 ### Complete Book Cover Selection System - GitHub Issue #46 RESOLVED!

--- a/src/components/BookLibrary.tsx
+++ b/src/components/BookLibrary.tsx
@@ -28,6 +28,7 @@ import {
   GridView,
   ViewList,
   FormatListBulleted,
+  Refresh,
 } from '@mui/icons-material'
 import type { EnhancedBook, CuratedGenre } from '@/lib/types'
 import { getBooks, updateBook, deleteBook as deleteBookAPI } from '@/lib/api'
@@ -446,15 +447,42 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
   const [genreUpdateSuccessful, setGenreUpdateSuccessful] = useState(false)
   const [userPermissions, setUserPermissions] = useState<string[]>([])
   const [permissionsChecked, setPermissionsChecked] = useState(false)
+  const [dataLoaded, setDataLoaded] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
 
   useEffect(() => {
-    if (session?.user) {
+    if (session?.user && !dataLoaded) {
       loadUserData()
+      setDataLoaded(true)
     } else if (session === null) {
       // Session loading is complete but user is not logged in
       setIsLoading(false)
+      setDataLoaded(false)
     }
-  }, [session])
+  }, [session, dataLoaded])
+
+  const handleManualRefresh = async () => {
+    if (isRefreshing) return // Prevent multiple simultaneous refreshes
+    
+    setIsRefreshing(true)
+    try {
+      await loadUserData()
+      await alert({
+        title: 'Library Refreshed',
+        message: 'Your library has been refreshed with the latest data.',
+        variant: 'success'
+      })
+    } catch (error) {
+      console.error('Error refreshing library:', error)
+      await alert({
+        title: 'Refresh Failed',
+        message: 'Failed to refresh library. Please try again.',
+        variant: 'error'
+      })
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
 
   // Initialize filters from URL on mount
   useEffect(() => {
@@ -1830,10 +1858,20 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
   return (
     <Container maxWidth="xl" sx={{ py: 2 }}>
       <Paper sx={{ p: 3 }}>
-        <Box sx={{ mb: 3 }}>
+        <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <Typography variant="h4" component="h2">
             {getLibraryTitle()}
           </Typography>
+          <Button
+            variant="outlined"
+            startIcon={isRefreshing ? <CircularProgress size={20} /> : <Refresh />}
+            onClick={handleManualRefresh}
+            disabled={isRefreshing}
+            size="small"
+            sx={{ minWidth: 110 }}
+          >
+            {isRefreshing ? 'Refreshing...' : 'Refresh'}
+          </Button>
         </Box>
 
 


### PR DESCRIPTION
## Summary
- Fixed unnecessary content refreshes when switching tabs/windows and returning to the application
- Added smart state management to prevent data reload when app state hasn't changed
- Implemented manual refresh functionality with refresh button in library header

## Technical Changes
- Modified BookLibrary.tsx useEffect hook to only load data when session exists and data hasn't been loaded
- Added dataLoaded and isRefreshing state variables for proper loading state management
- Implemented handleManualRefresh function providing user-controlled refresh capability
- Reset dataLoaded flag when session becomes null for proper cleanup
- Follow existing pattern from AppLayout.tsx for refresh prevention

## Test Plan
- [x] Screenshot automation test passed
- [x] Build verification completed successfully
- [x] Manual testing confirmed refresh button works correctly
- [x] Verified no unnecessary API calls on tab focus changes
- [x] Confirmed existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)