### PR TITLE
feat: restructure Profile page into focused screens

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## July 14, 2025 - Profile Page Restructure Implementation
+
+### Complete Profile Page Restructure - GitHub Issue #55 RESOLVED!
+- **RESTRUCTURED**: Monolithic Profile page into four focused, single-purpose screens for improved UX and code organization
+- **CREATED**: Simplified Profile page (`/profile`) containing only essential user information: email, first name, last name, and password management
+- **EXTRACTED**: Locations page (`/locations`) with complete location management functionality including leave location capability and permission checks
+- **EXTRACTED**: Checkout History page (`/checkout-history`) displaying comprehensive checkout and return history with book details and action dates
+- **CREATED**: Settings page (`/settings`) with dark/light mode toggle functionality moved from header for better organization
+- **UPDATED**: Navigation dropdown in AppLayout to include new menu items (Locations, Checkout History, Settings) linked from user account menu
+- **REMOVED**: Dark mode toggle from header, consolidating theme controls into dedicated Settings page
+- **MAINTAINED**: All existing functionality while improving code organization and user experience through focused page responsibilities
+
+### Profile Page Restructure Technical Implementation
+- **SIMPLIFIED**: Profile page interface removing bio field implementation per user request to focus on core profile data
+- **MODULARIZED**: Profile functionality into dedicated pages with clear separation of concerns and improved maintainability
+- **ENHANCED**: Navigation structure with logical grouping of profile-related functions in dropdown menu
+- **PRESERVED**: All authentication flows, permission checks, and user data management while restructuring UI organization
+- **IMPLEMENTED**: Consistent Material UI styling and user experience patterns across all new profile-related pages
+- **OPTIMIZED**: User workflow by organizing related functionality into focused screens accessible through intuitive navigation
+
+### User Experience Improvements
+- **FOCUSED**: Profile page on essential user information (email, names, password) without distracting secondary features
+- **ORGANIZED**: Location management into dedicated page with proper permission handling and leave functionality
+- **CENTRALIZED**: Checkout history viewing in dedicated page with comprehensive activity tracking and book details
+- **CONSOLIDATED**: Application settings into focused Settings page with theme toggle and future setting expansion capability
+- **STREAMLINED**: Navigation flow with logical menu organization and consistent user experience across all profile-related screens
+- **ENHANCED**: Overall application organization by separating profile data management from location management and settings
+
 ## July 14, 2025 - Unnecessary Content Refresh Prevention System Implementation
 
 ### Complete Refresh Prevention System - GitHub Issue #50 RESOLVED!

--- a/src/app/checkout-history/page.tsx
+++ b/src/app/checkout-history/page.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import {
+  Container,
+  Paper,
+  Typography,
+  Button,
+  Box,
+  Alert,
+  CircularProgress,
+  Card,
+  CardContent,
+} from '@mui/material'
+import {
+  ArrowBack,
+  History,
+  Book,
+} from '@mui/icons-material'
+import Footer from '@/components/Footer'
+
+interface CheckoutHistoryItem {
+  id: number
+  book_id: number
+  user_id: string
+  action: string // 'checkout' or 'return'
+  action_date: string
+  due_date: string | null
+  notes: string | null
+  created_at: string
+  book_title: string
+  book_authors: string[] // JSON parsed array
+  book_isbn: string
+  location_name: string
+}
+
+export default function CheckoutHistoryPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [checkoutHistory, setCheckoutHistory] = useState<CheckoutHistoryItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin')
+      return
+    }
+
+    if (status === 'authenticated') {
+      fetchCheckoutHistory()
+    }
+  }, [status, router])
+
+  const fetchCheckoutHistory = async () => {
+    try {
+      if (!session?.user?.email) return
+      
+      const response = await fetch('/api/checkout-history', {
+        headers: {
+          'Authorization': `Bearer ${session.user.email}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      if (response.ok) {
+        const historyData = await response.json()
+        setCheckoutHistory(historyData)
+      }
+    } catch (err) {
+      console.error('Failed to load checkout history:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (status === 'loading' || loading) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4, textAlign: 'center' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
+          <CircularProgress />
+          <Typography>Loading...</Typography>
+        </Box>
+      </Container>
+    )
+  }
+
+  if (!session) {
+    return null
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 3 }}>
+      <Paper sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+          <Button 
+            variant="outlined"
+            startIcon={<ArrowBack />}
+            onClick={() => router.push('/')}
+          >
+            Back to App
+          </Button>
+          <Typography variant="h4" component="h1" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <History /> Checkout History
+          </Typography>
+        </Box>
+        
+        {checkoutHistory.length === 0 ? (
+          <Paper variant="outlined" sx={{ p: 3, textAlign: 'center', backgroundColor: 'grey.50' }}>
+            <Typography color="text.secondary">
+              No checkout history yet. Check out a book to see your reading activity here.
+            </Typography>
+          </Paper>
+        ) : (
+          <Box>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+              Your complete book checkout and return activity ({checkoutHistory.length} record{checkoutHistory.length > 1 ? 's' : ''}).
+            </Typography>
+            
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {checkoutHistory.map(item => (
+                <Card key={item.id} variant="outlined">
+                  <CardContent>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                      <Box sx={{ flex: 1 }}>
+                        <Typography variant="h6" component="h2" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Book fontSize="small" />
+                          {item.book_title}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          by {Array.isArray(item.book_authors) ? item.book_authors.join(', ') : item.book_authors}
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          {item.location_name}
+                        </Typography>
+                        {item.book_isbn && (
+                          <Typography variant="caption" color="text.secondary">
+                            ISBN: {item.book_isbn}
+                          </Typography>
+                        )}
+                        {item.notes && (
+                          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
+                            {item.notes}
+                          </Typography>
+                        )}
+                      </Box>
+                      
+                      <Box sx={{ textAlign: 'right', ml: 2 }}>
+                        <Typography 
+                          variant="body2" 
+                          sx={{ 
+                            color: item.action === 'checkout' ? 'success.main' : 'info.main',
+                            fontWeight: 500,
+                            textTransform: 'capitalize'
+                          }}
+                        >
+                          {item.action === 'checkout' ? 'Checked Out' : 'Returned'}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {new Date(item.action_date).toLocaleDateString()}
+                        </Typography>
+                        {item.due_date && item.action === 'checkout' && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                            Due: {new Date(item.due_date).toLocaleDateString()}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  </CardContent>
+                </Card>
+              ))}
+            </Box>
+          </Box>
+        )}
+      </Paper>
+      
+      <Footer />
+    </Container>
+  )
+}

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -1,0 +1,262 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import {
+  Container,
+  Paper,
+  Typography,
+  Button,
+  Box,
+  Alert,
+  CircularProgress,
+  Card,
+  CardContent,
+} from '@mui/material'
+import {
+  ArrowBack,
+  LocationOn,
+  ExitToApp,
+} from '@mui/icons-material'
+import ConfirmationModal from '@/components/ConfirmationModal'
+import AlertModal from '@/components/AlertModal'
+import Footer from '@/components/Footer'
+import { useModal } from '@/hooks/useModal'
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.librarycard.tim52.io'
+
+interface Location {
+  id: number
+  name: string
+  description?: string
+  owner_id: string
+  created_at: string
+}
+
+interface ProfileData {
+  user_role: string
+}
+
+export default function LocationsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const { modalState, confirmAsync, alert, closeModal } = useModal()
+  const [locations, setLocations] = useState<Location[]>([])
+  const [profile, setProfile] = useState<ProfileData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin')
+      return
+    }
+
+    if (status === 'authenticated') {
+      fetchProfile()
+      fetchLocations()
+    }
+  }, [status, router])
+
+  const fetchProfile = async () => {
+    try {
+      const response = await fetch('/api/profile')
+      if (response.ok) {
+        const profileData = await response.json()
+        setProfile(profileData)
+      }
+    } catch (error) {
+      console.error('Failed to load profile:', error)
+    }
+  }
+
+  const fetchLocations = async () => {
+    try {
+      if (!session?.user?.email) return
+      
+      const response = await fetch(`${API_BASE}/api/locations`, {
+        headers: {
+          'Authorization': `Bearer ${session.user.email}`,
+          'Content-Type': 'application/json',
+        },
+      })
+      if (response.ok) {
+        const locationsData = await response.json()
+        setLocations(locationsData)
+      }
+    } catch (error) {
+      console.error('Failed to load locations:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const leaveLocation = async (locationId: number, locationName: string) => {
+    const confirmed = await confirmAsync(
+      {
+        title: 'Leave Location',
+        message: `Are you sure you want to leave "${locationName}"? This will remove all your books from this location and cannot be undone.`,
+        confirmText: 'Leave Location',
+        variant: 'danger'
+      },
+      async () => {
+        const response = await fetch(`${API_BASE}/api/locations/${locationId}/leave`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${session?.user?.email}`,
+            'Content-Type': 'application/json',
+          },
+        })
+
+        if (response.ok) {
+          await fetchLocations() // Refresh locations list
+          await alert({
+            title: 'Left Location',
+            message: `Successfully left "${locationName}". Your books from this location have been removed.`,
+            variant: 'success'
+          })
+        } else {
+          const errorData = await response.json()
+          throw new Error(errorData.error || `Failed to leave "${locationName}"`)
+        }
+      }
+    )
+
+    if (!confirmed) {
+      await alert({
+        title: 'Leave Failed',
+        message: 'Failed to leave the location. Please try again.',
+        variant: 'error'
+      })
+    }
+  }
+
+  if (status === 'loading' || loading) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4, textAlign: 'center' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
+          <CircularProgress />
+          <Typography>Loading...</Typography>
+        </Box>
+      </Container>
+    )
+  }
+
+  if (!session || !profile) {
+    return null
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 3 }}>
+      <Paper sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+          <Button 
+            variant="outlined"
+            startIcon={<ArrowBack />}
+            onClick={() => router.push('/')}
+          >
+            Back to App
+          </Button>
+          <Typography variant="h4" component="h1" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <LocationOn /> Library Locations
+          </Typography>
+        </Box>
+        
+        {locations.length === 0 ? (
+          <Paper variant="outlined" sx={{ p: 3, textAlign: 'center', backgroundColor: 'grey.50' }}>
+            <Typography color="text.secondary">
+              You don&apos;t have access to any library locations yet. Contact an administrator to get invited.
+            </Typography>
+          </Paper>
+        ) : (
+          <Box>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+              You have access to {locations.length} library location{locations.length > 1 ? 's' : ''}.
+              {profile?.user_role !== 'admin' && profile?.user_role !== 'super_admin' && ' You can leave locations you no longer need access to.'}
+            </Typography>
+            
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {locations.map(location => (
+                <Card key={location.id} variant="outlined">
+                  <CardContent>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <Box>
+                        <Typography variant="h6" component="h2">
+                          {location.name}
+                        </Typography>
+                        {location.description && (
+                          <Typography variant="body2" color="text.secondary">
+                            {location.description}
+                          </Typography>
+                        )}
+                        <Typography variant="caption" color="text.secondary">
+                          Added: {new Date(location.created_at).toLocaleDateString()}
+                        </Typography>
+                      </Box>
+                      
+                      {locations.length > 1 && profile?.user_role !== 'admin' && profile?.user_role !== 'super_admin' && (
+                        <Button
+                          variant="contained"
+                          color="error"
+                          size="small"
+                          startIcon={<ExitToApp />}
+                          onClick={() => leaveLocation(location.id, location.name)}
+                        >
+                          Leave Location
+                        </Button>
+                      )}
+                    </Box>
+                  </CardContent>
+                </Card>
+              ))}
+            </Box>
+            
+            {locations.length === 1 && profile?.user_role !== 'admin' && profile?.user_role !== 'super_admin' && (
+              <Alert severity="warning" sx={{ mt: 2 }}>
+                <Typography variant="body2">
+                  You can&apos;t leave your last location. You need access to at least one library.
+                </Typography>
+              </Alert>
+            )}
+            
+            {(profile?.user_role === 'admin' || profile?.user_role === 'super_admin') && (
+              <Alert severity="info" sx={{ mt: 2 }}>
+                <Typography variant="body2">
+                  As an admin, you cannot leave locations. Admins must maintain access to manage library settings.
+                </Typography>
+              </Alert>
+            )}
+          </Box>
+        )}
+        
+        {/* Modal Components */}
+        {modalState.type === 'confirm' && (
+          <ConfirmationModal
+            isOpen={modalState.isOpen}
+            onClose={closeModal}
+            onConfirm={modalState.onConfirm!}
+            title={modalState.options.title}
+            message={modalState.options.message}
+            confirmText={modalState.options.confirmText}
+            cancelText={modalState.options.cancelText}
+            variant={modalState.options.variant}
+            loading={modalState.loading}
+          />
+        )}
+        
+        {modalState.type === 'alert' && (
+          <AlertModal
+            isOpen={modalState.isOpen}
+            onClose={closeModal}
+            title={modalState.options.title}
+            message={modalState.options.message}
+            variant={modalState.options.variant}
+            buttonText={modalState.options.buttonText}
+          />
+        )}
+      </Paper>
+      
+      <Footer />
+    </Container>
+  )
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,8 +12,6 @@ import {
   TextField,
   Alert,
   CircularProgress,
-  Card,
-  CardContent,
   Divider,
   InputAdornment,
   IconButton,
@@ -22,10 +20,6 @@ import {
   ArrowBack,
   Save,
   Person,
-  LocationOn,
-  ExitToApp,
-  History,
-  Book,
   Lock,
   Visibility,
   VisibilityOff,
@@ -34,8 +28,6 @@ import ConfirmationModal from '@/components/ConfirmationModal'
 import AlertModal from '@/components/AlertModal'
 import Footer from '@/components/Footer'
 import { useModal } from '@/hooks/useModal'
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.librarycard.tim52.io'
 
 interface ProfileData {
   id: string
@@ -46,38 +38,12 @@ interface ProfileData {
   user_role: string
 }
 
-interface Location {
-  id: number
-  name: string
-  description?: string
-  owner_id: string
-  created_at: string
-}
-
-interface CheckoutHistoryItem {
-  id: number
-  book_id: number
-  user_id: string
-  action: string // 'checkout' or 'return'
-  action_date: string
-  due_date: string | null
-  notes: string | null
-  created_at: string
-  book_title: string
-  book_authors: string[] // JSON parsed array
-  book_isbn: string
-  location_name: string
-}
-
 export default function ProfilePage() {
   const { data: session, status } = useSession()
   const router = useRouter()
-  const { modalState, confirmAsync, alert, closeModal } = useModal()
+  const { modalState, closeModal } = useModal()
   const [profile, setProfile] = useState<ProfileData | null>(null)
-  const [locations, setLocations] = useState<Location[]>([])
-  const [checkoutHistory, setCheckoutHistory] = useState<CheckoutHistoryItem[]>([])
   const [loading, setLoading] = useState(true)
-  const [historyLoading, setHistoryLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
@@ -108,8 +74,6 @@ export default function ProfilePage() {
 
     if (status === 'authenticated') {
       fetchProfile()
-      fetchLocations()
-      fetchCheckoutHistory()
     }
   }, [status, router])
 
@@ -131,87 +95,6 @@ export default function ProfilePage() {
       setError('Failed to load profile data')
     } finally {
       setLoading(false)
-    }
-  }
-
-  const fetchLocations = async () => {
-    try {
-      if (!session?.user?.email) return
-      
-      const response = await fetch(`${API_BASE}/api/locations`, {
-        headers: {
-          'Authorization': `Bearer ${session.user.email}`,
-          'Content-Type': 'application/json',
-        },
-      })
-      if (response.ok) {
-        const locationsData = await response.json()
-        setLocations(locationsData)
-      }
-    } catch (error) {
-      console.error('Failed to load locations:', error)
-    }
-  }
-
-  const fetchCheckoutHistory = async () => {
-    try {
-      setHistoryLoading(true)
-      if (!session?.user?.email) return
-      
-      const response = await fetch('/api/checkout-history', {
-        headers: {
-          'Authorization': `Bearer ${session.user.email}`,
-          'Content-Type': 'application/json',
-        },
-      })
-      if (response.ok) {
-        const historyData = await response.json()
-        setCheckoutHistory(historyData)
-      }
-    } catch (err) {
-      console.error('Failed to load checkout history:', err)
-    } finally {
-      setHistoryLoading(false)
-    }
-  }
-
-  const leaveLocation = async (locationId: number, locationName: string) => {
-    const confirmed = await confirmAsync(
-      {
-        title: 'Leave Location',
-        message: `Are you sure you want to leave "${locationName}"? This will remove all your books from this location and cannot be undone.`,
-        confirmText: 'Leave Location',
-        variant: 'danger'
-      },
-      async () => {
-        const response = await fetch(`${API_BASE}/api/locations/${locationId}/leave`, {
-          method: 'POST',
-          headers: {
-            'Authorization': `Bearer ${session?.user?.email}`,
-            'Content-Type': 'application/json',
-          },
-        })
-
-        if (response.ok) {
-          await fetchLocations() // Refresh locations list
-          await alert({
-            title: 'Left Location',
-            message: `Successfully left "${locationName}". Your books from this location have been removed.`,
-            variant: 'success'
-          })
-        } else {
-          const errorData = await response.json()
-          throw new Error(errorData.error || `Failed to leave "${locationName}"`)
-        }
-      }
-    )
-
-    if (!confirmed) {
-      await alert({
-        title: 'Leave Failed',
-        message: 'Failed to leave the location. Please try again.',
-        variant: 'error'
-      })
     }
   }
 
@@ -353,7 +236,7 @@ export default function ProfilePage() {
             Back to App
           </Button>
           <Typography variant="h4" component="h1" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Person /> Edit Profile
+            <Person /> Profile
           </Typography>
         </Box>
         
@@ -525,156 +408,6 @@ export default function ProfilePage() {
             </Box>
           </>
         )}
-
-        <Divider sx={{ my: 3 }} />
-        
-        <Typography variant="h5" component="h2" sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-          <LocationOn /> Library Locations
-        </Typography>
-        
-        {locations.length === 0 ? (
-          <Paper variant="outlined" sx={{ p: 3, textAlign: 'center', backgroundColor: 'grey.50' }}>
-            <Typography color="text.secondary">
-              You don&apos;t have access to any library locations yet. Contact an administrator to get invited.
-            </Typography>
-          </Paper>
-        ) : (
-          <Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              You have access to {locations.length} library location{locations.length > 1 ? 's' : ''}.
-              {profile?.user_role !== 'admin' && ' You can leave locations you no longer need access to.'}
-            </Typography>
-            
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-              {locations.map(location => (
-                <Card key={location.id} variant="outlined">
-                  <CardContent>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <Box>
-                        <Typography variant="h6" component="h4">
-                          {location.name}
-                        </Typography>
-                        {location.description && (
-                          <Typography variant="body2" color="text.secondary">
-                            {location.description}
-                          </Typography>
-                        )}
-                      </Box>
-                      
-                      {locations.length > 1 && profile?.user_role !== 'admin' && (
-                        <Button
-                          variant="contained"
-                          color="error"
-                          size="small"
-                          startIcon={<ExitToApp />}
-                          onClick={() => leaveLocation(location.id, location.name)}
-                        >
-                          Leave Location
-                        </Button>
-                      )}
-                    </Box>
-                  </CardContent>
-                </Card>
-              ))}
-            </Box>
-            
-            {locations.length === 1 && profile?.user_role !== 'admin' && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                <Typography variant="body2">
-                  You can&apos;t leave your last location. You need access to at least one library.
-                </Typography>
-              </Alert>
-            )}
-            
-            {profile?.user_role === 'admin' && (
-              <Alert severity="info" sx={{ mt: 2 }}>
-                <Typography variant="body2">
-                  As an admin, you cannot leave locations. Admins must maintain access to manage library settings.
-                </Typography>
-              </Alert>
-            )}
-          </Box>
-        )}
-        
-        <Divider sx={{ my: 3 }} />
-        
-        <Typography variant="h5" component="h2" sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
-          <History /> Checkout History
-        </Typography>
-        
-        {historyLoading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, p: 3 }}>
-            <CircularProgress size={20} />
-            <Typography>Loading checkout history...</Typography>
-          </Box>
-        ) : checkoutHistory.length === 0 ? (
-          <Paper variant="outlined" sx={{ p: 3, textAlign: 'center', backgroundColor: 'grey.50' }}>
-            <Typography color="text.secondary">
-              No checkout history yet. Check out a book to see your reading activity here.
-            </Typography>
-          </Paper>
-        ) : (
-          <Box>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Your recent book checkout and return activity ({checkoutHistory.length} record{checkoutHistory.length > 1 ? 's' : ''}).
-            </Typography>
-            
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-              {checkoutHistory.slice(0, 10).map(item => (
-                <Card key={item.id} variant="outlined">
-                  <CardContent>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                      <Box sx={{ flex: 1 }}>
-                        <Typography variant="h6" component="h4" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <Book fontSize="small" />
-                          {item.book_title}
-                        </Typography>
-                        <Typography variant="body2" color="text.secondary">
-                          by {Array.isArray(item.book_authors) ? item.book_authors.join(', ') : item.book_authors}
-                        </Typography>
-                        {item.notes && (
-                          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, fontStyle: 'italic' }}>
-                            {item.notes}
-                          </Typography>
-                        )}
-                      </Box>
-                      
-                      <Box sx={{ textAlign: 'right', ml: 2 }}>
-                        <Typography 
-                          variant="body2" 
-                          sx={{ 
-                            color: item.action === 'checkout' ? 'success.main' : 'info.main',
-                            fontWeight: 500,
-                            textTransform: 'capitalize'
-                          }}
-                        >
-                          {item.action === 'checkout' ? 'Checked Out' : 'Returned'}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {new Date(item.action_date).toLocaleDateString()}
-                        </Typography>
-                        {item.due_date && item.action === 'checkout' && (
-                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                            Due: {new Date(item.due_date).toLocaleDateString()}
-                          </Typography>
-                        )}
-                      </Box>
-                    </Box>
-                  </CardContent>
-                </Card>
-              ))}
-            </Box>
-            
-            {checkoutHistory.length > 10 && (
-              <Alert severity="info" sx={{ mt: 2 }}>
-                <Typography variant="body2">
-                  Showing most recent 10 entries. You have {checkoutHistory.length - 10} more entries in your history.
-                </Typography>
-              </Alert>
-            )}
-          </Box>
-        )}
-
         
         {/* Modal Components */}
         {modalState.type === 'confirm' && (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import {
+  Container,
+  Paper,
+  Typography,
+  Button,
+  Box,
+  Card,
+  CardContent,
+  Switch,
+  FormControlLabel,
+  Divider,
+  Alert,
+} from '@mui/material'
+import {
+  ArrowBack,
+  Settings,
+  DarkMode,
+  LightMode,
+  Palette,
+} from '@mui/icons-material'
+import Footer from '@/components/Footer'
+import { useTheme } from '@/lib/ThemeContext'
+
+export default function SettingsPage() {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const { isDarkMode, toggleTheme } = useTheme()
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin')
+      return
+    }
+
+    if (status === 'authenticated') {
+      setLoading(false)
+    }
+  }, [status, router])
+
+  if (status === 'loading' || loading) {
+    return (
+      <Container maxWidth="md" sx={{ py: 4, textAlign: 'center' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
+          <Typography>Loading...</Typography>
+        </Box>
+      </Container>
+    )
+  }
+
+  if (!session) {
+    return null
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 3 }}>
+      <Paper sx={{ p: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
+          <Button 
+            variant="outlined"
+            startIcon={<ArrowBack />}
+            onClick={() => router.push('/')}
+          >
+            Back to App
+          </Button>
+          <Typography variant="h4" component="h1" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Settings /> Settings
+          </Typography>
+        </Box>
+
+        <Alert severity="info" sx={{ mb: 3 }}>
+          <Typography variant="body2">
+            Customize your LibraryCard experience with these settings.
+          </Typography>
+        </Alert>
+
+        {/* Appearance Settings */}
+        <Typography variant="h5" component="h2" sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Palette /> Appearance
+        </Typography>
+        
+        <Card variant="outlined" sx={{ mb: 3 }}>
+          <CardContent>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Box>
+                <Typography variant="h6" component="h3" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  {isDarkMode ? <DarkMode /> : <LightMode />}
+                  Dark Mode
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {isDarkMode ? 'Using dark theme' : 'Using light theme'}
+                </Typography>
+              </Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={isDarkMode}
+                    onChange={toggleTheme}
+                  />
+                }
+                label=""
+              />
+            </Box>
+          </CardContent>
+        </Card>
+
+        <Divider sx={{ my: 3 }} />
+
+        {/* Future Settings Section */}
+        <Typography variant="h5" component="h2" sx={{ mb: 2 }}>
+          More Settings Coming Soon
+        </Typography>
+        
+        <Alert severity="info">
+          <Typography variant="body2">
+            Additional customization options will be added here in future updates, including notification preferences, display options, and more.
+          </Typography>
+        </Alert>
+      </Paper>
+      
+      <Footer />
+    </Container>
+  )
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -22,10 +22,11 @@ import {
   LibraryBooks,
   AccountCircle,
   ExitToApp,
-  DarkMode,
-  LightMode,
   Help,
   Dashboard,
+  LocationOn,
+  History,
+  Settings,
 } from '@mui/icons-material'
 import Footer from '@/components/Footer'
 import HelpModal from '@/components/HelpModal'
@@ -164,6 +165,21 @@ export default function AppLayout({ children, currentPage }: AppLayoutProps) {
     handleMenuClose()
   }
 
+  const handleLocationsClick = () => {
+    router.push('/locations')
+    handleMenuClose()
+  }
+
+  const handleCheckoutHistoryClick = () => {
+    router.push('/checkout-history')
+    handleMenuClose()
+  }
+
+  const handleSettingsClick = () => {
+    router.push('/settings')
+    handleMenuClose()
+  }
+
   const handleHelpClick = () => {
     setHelpModalOpen(true)
     handleMenuClose()
@@ -184,16 +200,6 @@ export default function AppLayout({ children, currentPage }: AppLayoutProps) {
           <Typography variant="body2" sx={{ mr: 2 }}>
             Hello, {userFirstName || session?.user?.name?.split(' ')[0] || 'User'}!
           </Typography>
-          
-          <IconButton
-            color="inherit"
-            onClick={toggleTheme}
-            size="small"
-            sx={{ mr: 1 }}
-            title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-          >
-            {isDarkMode ? <LightMode /> : <DarkMode />}
-          </IconButton>
           
           <IconButton
             color="inherit"
@@ -219,6 +225,18 @@ export default function AppLayout({ children, currentPage }: AppLayoutProps) {
             <MenuItem onClick={handleProfileClick}>
               <AccountCircle sx={{ mr: 1 }} />
               Profile
+            </MenuItem>
+            <MenuItem onClick={handleLocationsClick}>
+              <LocationOn sx={{ mr: 1 }} />
+              Locations
+            </MenuItem>
+            <MenuItem onClick={handleCheckoutHistoryClick}>
+              <History sx={{ mr: 1 }} />
+              Checkout History
+            </MenuItem>
+            <MenuItem onClick={handleSettingsClick}>
+              <Settings sx={{ mr: 1 }} />
+              Settings
             </MenuItem>
             <MenuItem onClick={handleHelpClick}>
               <Help sx={{ mr: 1 }} />


### PR DESCRIPTION
## Summary
- Break monolithic Profile page into four focused screens for improved UX and code organization
- Create simplified Profile page with only essential user information (email, names, password)
- Extract location management functionality into dedicated Locations page  
- Extract checkout history into dedicated Checkout History page
- Create Settings page with dark/light mode toggle (moved from header)

## Test plan
- [x] Verify all new pages load correctly and maintain existing functionality
- [x] Test navigation between pages through dropdown menu
- [x] Confirm profile data editing works on simplified Profile page
- [x] Validate location management features on Locations page
- [x] Check checkout history display on Checkout History page
- [x] Test dark/light mode toggle on Settings page
- [x] Verify build and lint success with no errors
- [x] Confirm all existing authentication and permission flows work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)