### PR TITLE
fix: unify Edit Genres button styling across all view modes

### DIFF
--- a/src/components/BookCompact.tsx
+++ b/src/components/BookCompact.tsx
@@ -291,11 +291,7 @@ export default function BookList({
                       onClick={() => onGenreEdit(book)}
                       sx={{ 
                         textTransform: 'none',
-                        fontSize: { xs: '0.75rem', sm: '0.8125rem' },
-                        color: 'secondary.main',
-                        '&:hover': {
-                          backgroundColor: 'secondary.50'
-                        }
+                        fontSize: { xs: '0.75rem', sm: '0.8125rem' }
                       }}
                     >
                       Edit Genres
@@ -331,11 +327,7 @@ export default function BookList({
                       onClick={() => onGenreEdit(book)}
                       sx={{ 
                         textTransform: 'none',
-                        fontSize: { xs: '0.75rem', sm: '0.8125rem' },
-                        color: 'secondary.main',
-                        '&:hover': {
-                          backgroundColor: 'secondary.50'
-                        }
+                        fontSize: { xs: '0.75rem', sm: '0.8125rem' }
                       }}
                     >
                       Edit Genres

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -225,11 +225,7 @@ export default function BookText({
                   size="small"
                   onClick={() => onGenreEdit(book)}
                   sx={{ 
-                    p: 0.5,
-                    color: 'secondary.main',
-                    '&:hover': {
-                      backgroundColor: 'secondary.50'
-                    }
+                    p: 0.5
                   }}
                   title="Edit Genres"
                 >


### PR DESCRIPTION
## Summary
Quick bugfix for GitHub issue #53 to unify the "Edit Genres" button styling across all view modes.

## Problem
The "Edit Genres" button appeared too light (secondary color) in compact and list views compared to the dark purple (primary color) in grid view, making it look inactive.

## Solution
Removed the explicit  styling from both compact and list view components, allowing them to use the default primary color styling that matches the grid view.

## Changes Made
- **BookCompact.tsx**: Removed  and hover styling from both Edit Genres button instances
- **BookList.tsx**: Removed  and hover styling from Edit Genres IconButton

## Test plan
- [x] Build verification passes
- [x] Edit Genres button now uses consistent primary color across all three view modes
- [x] Button styling matches between grid, compact, and list views

**Before**: Edit Genres appeared light gray/secondary color in compact/list views  
**After**: Edit Genres appears dark purple (primary color) consistently across all views

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)