### PR TITLE
Fix: Add location grouping to book relocation modal for multi-location users

### DIFF
--- a/src/components/BookLibrary.tsx
+++ b/src/components/BookLibrary.tsx
@@ -2454,13 +2454,54 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
                       handleRelocateBook(newShelfId)
                     }}
                   >
-                    {shelves
-                      .filter(shelf => shelf.id !== selectedBookForRelocate.shelf_id)
-                      .map(shelf => (
-                        <MenuItem key={shelf.id} value={shelf.id}>
-                          {shelf.name}
-                        </MenuItem>
-                      ))}
+                    {(() => {
+                      const availableShelves = shelves.filter(shelf => shelf.id !== selectedBookForRelocate.shelf_id)
+                      
+                      if (allLocations.length === 1) {
+                        // Single location - simple list without grouping
+                        return availableShelves.map(shelf => (
+                          <MenuItem key={shelf.id} value={shelf.id}>
+                            {shelf.name}
+                          </MenuItem>
+                        ))
+                      } else {
+                        // Multiple locations - group by location
+                        return allLocations.map(location => {
+                          const locationShelves = availableShelves.filter(shelf => shelf.location_id === location.id)
+                          
+                          // Skip locations with no available shelves
+                          if (locationShelves.length === 0) {
+                            return null
+                          }
+
+                          return [
+                            <MenuItem 
+                              key={`${location.id}-header`} 
+                              disabled 
+                              sx={{ 
+                                fontWeight: 'bold',
+                                backgroundColor: 'action.hover',
+                                '&.Mui-disabled': {
+                                  opacity: 1,
+                                  color: 'text.primary'
+                                }
+                              }}
+                            >
+                              📍 {location.name}
+                            </MenuItem>,
+                            ...locationShelves.map(shelf => (
+                              <MenuItem 
+                                key={shelf.id} 
+                                value={shelf.id} 
+                                sx={{ pl: 3 }}
+                              >
+                                📚 {shelf.name}
+                              </MenuItem>
+                            ))
+                          ]
+                        }).filter(Boolean).flat()
+                      }
+                    })()}
                   </Select>
                 </FormControl>
               )}


### PR DESCRIPTION
## Summary
- **Fixed** book relocation modal to group shelves by location for multi-location users
- **Added** location headers (📍 Location Name) and indented shelf items (📚 Shelf Name) 
- **Maintained** consistency with book addition shelf selection interface (ShelfSelector component)

## Problem
When multi-location users relocate a book, they only see a flat list of shelf names without location context, making it difficult to identify which location each shelf belongs to.

## Solution
Updated the relocation modal to use the same location grouping logic as the `ShelfSelector` component:

### For Single Location
- Shows simple shelf list without grouping (no change needed)

### For Multiple Locations  
- **Location headers**: Disabled menu items with 📍 icon and location name
- **Indented shelf items**: Shelf names with 📚 icon and left padding (pl: 3)
- **Smart filtering**: Only shows locations that have available shelves (excludes current shelf)

## Technical Details
- Modified `BookLibrary.tsx` relocation modal (lines 2457-2504)
- Replaced flat shelf mapping with conditional location grouping logic
- Used `allLocations` state instead of undefined `locations` variable
- Follows exact same pattern as `ShelfSelector.tsx` component

## Test Plan
- [x] Verify build passes without TypeScript errors
- [x] Confirm lint warnings are not related to changes
- [x] Test single location scenario (should show simple list)
- [x] Test multi-location scenario (should show grouped by location)
- [x] Verify correct shelf filtering (excludes current shelf)

**Resolves:** #70

🤖 Generated with [Claude Code](https://claude.ai/code)