### PR TITLE
Fix Add Books tab routing and smooth transitions

### DIFF
--- a/src/app/add-books/page.tsx
+++ b/src/app/add-books/page.tsx
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { Container, CircularProgress, Typography, Box } from '@mui/material'
+import AddBooks from '@/components/book/AddBooks'
 
 export default function AddBooksPage() {
   const { data: session, status } = useSession()
@@ -13,11 +14,7 @@ export default function AddBooksPage() {
     if (status === 'loading') return
     if (!session) {
       router.push('/auth/signin')
-      return
     }
-
-    // Redirect to the default tab (search)
-    router.push('/add-books/search')
   }, [session, status, router])
 
   if (status === 'loading') {
@@ -31,5 +28,9 @@ export default function AddBooksPage() {
     )
   }
 
-  return null
+  if (!session) {
+    return null
+  }
+
+  return <AddBooks />
 }

--- a/src/app/add-books/scan/page.tsx
+++ b/src/app/add-books/scan/page.tsx
@@ -3,8 +3,6 @@
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
-import { Container, CircularProgress, Typography, Box } from '@mui/material'
-import AddBooks from '@/components/book/AddBooks'
 
 export default function AddBooksScanPage() {
   const { data: session, status } = useSession()
@@ -14,23 +12,12 @@ export default function AddBooksScanPage() {
     if (status === 'loading') return
     if (!session) {
       router.push('/auth/signin')
+      return
     }
+    
+    // Redirect to new URL parameter format
+    router.replace('/add-books?tab=scan')
   }, [session, status, router])
 
-  if (status === 'loading') {
-    return (
-      <Container maxWidth="lg" sx={{ py: 4, textAlign: 'center' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
-          <CircularProgress />
-          <Typography>Loading...</Typography>
-        </Box>
-      </Container>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  return <AddBooks initialTab="scan" />
+  return null
 }

--- a/src/app/add-books/search/page.tsx
+++ b/src/app/add-books/search/page.tsx
@@ -3,8 +3,6 @@
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
-import { Container, CircularProgress, Typography, Box } from '@mui/material'
-import AddBooks from '@/components/book/AddBooks'
 
 export default function AddBooksSearchPage() {
   const { data: session, status } = useSession()
@@ -14,23 +12,12 @@ export default function AddBooksSearchPage() {
     if (status === 'loading') return
     if (!session) {
       router.push('/auth/signin')
+      return
     }
+    
+    // Redirect to new URL parameter format
+    router.replace('/add-books')
   }, [session, status, router])
 
-  if (status === 'loading') {
-    return (
-      <Container maxWidth="lg" sx={{ py: 4, textAlign: 'center' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2 }}>
-          <CircularProgress />
-          <Typography>Loading...</Typography>
-        </Box>
-      </Container>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  return <AddBooks initialTab="search" />
+  return null
 }

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -2,9 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
+import { useSearchParams, useRouter } from 'next/navigation'
 import {
-  Container,
-  Paper,
   Typography,
   Box,
   CircularProgress,
@@ -12,6 +11,7 @@ import {
   Tabs,
   Tab,
   Button,
+  Fade,
 } from '@mui/material'
 import {
   Dashboard,
@@ -27,8 +27,19 @@ import AdminUserManager from './AdminUserManager'
 import AdminNotificationCenter from './AdminNotificationCenter'
 import AdminSignupManager from './AdminSignupManager'
 import LocationManager from './LocationManager'
+import PageContainer from '../layout/PageContainer'
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.librarycard.tim52.io'
+
+const TAB_NAMES = ['overview', 'analytics', 'users', 'locations', 'signup-requests', 'notifications']
+const TAB_INDEX_MAP: { [key: string]: number } = {
+  'overview': 0,
+  'analytics': 1,
+  'users': 2,
+  'locations': 3,
+  'signup-requests': 4,
+  'notifications': 5,
+}
 
 interface AdminOverview {
   totalBooks: number
@@ -42,11 +53,20 @@ interface AdminOverview {
 
 export default function AdminDashboard() {
   const { data: session } = useSession()
+  const searchParams = useSearchParams()
+  const router = useRouter()
   const [overview, setOverview] = useState<AdminOverview | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [activeTab, setActiveTab] = useState(0)
   const [dataLoaded, setDataLoaded] = useState(false)
+
+  useEffect(() => {
+    const tabFromUrl = searchParams.get('tab')
+    if (tabFromUrl && TAB_INDEX_MAP[tabFromUrl] !== undefined) {
+      setActiveTab(TAB_INDEX_MAP[tabFromUrl])
+    }
+  }, [searchParams])
 
   useEffect(() => {
     if (session?.user?.email && !dataLoaded) {
@@ -92,132 +112,161 @@ export default function AdminDashboard() {
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue)
+    const tabName = TAB_NAMES[newValue]
+    const params = new URLSearchParams(searchParams.toString())
+    
+    if (tabName === 'overview') {
+      params.delete('tab')
+    } else {
+      params.set('tab', tabName)
+    }
+    
+    const newUrl = params.toString() ? `?${params.toString()}` : ''
+    router.replace(`/admin${newUrl}`, { scroll: false })
   }
 
   if (loading) {
     return (
-      <Container maxWidth="xl" sx={{ py: 2 }}>
-        <Paper sx={{ p: 3 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            🔧 Admin Dashboard
+      <PageContainer>
+        <Typography variant="h4" component="h1" gutterBottom>
+          🔧 Admin Dashboard
+        </Typography>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 4 }}>
+          <CircularProgress sx={{ mr: 2 }} />
+          <Typography color="text.secondary">
+            Loading admin dashboard...
           </Typography>
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 4 }}>
-            <CircularProgress sx={{ mr: 2 }} />
-            <Typography color="text.secondary">
-              Loading admin dashboard...
-            </Typography>
-          </Box>
-        </Paper>
-      </Container>
+        </Box>
+      </PageContainer>
     )
   }
 
   if (error) {
     return (
-      <Container maxWidth="xl" sx={{ py: 2 }}>
-        <Paper sx={{ p: 3 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            🔧 Admin Dashboard
-          </Typography>
-          <Alert severity="error" sx={{ mt: 2 }}>
-            {error}
-          </Alert>
-        </Paper>
-      </Container>
+      <PageContainer>
+        <Typography variant="h4" component="h1" gutterBottom>
+          🔧 Admin Dashboard
+        </Typography>
+        <Alert severity="error" sx={{ mt: 2 }}>
+          {error}
+        </Alert>
+      </PageContainer>
     )
   }
 
   return (
-    <Container maxWidth="xl" sx={{ py: 2 }}>
-      <Paper sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h4" component="h1">
-            🔧 Admin Dashboard
-          </Typography>
-          <Button
-            variant="outlined"
-            startIcon={<Refresh />}
-            onClick={loadOverview}
-            size="small"
-          >
-            Refresh
-          </Button>
-        </Box>
+    <PageContainer>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h4" component="h1">
+          🔧 Admin Dashboard
+        </Typography>
+        <Button
+          variant="outlined"
+          startIcon={<Refresh />}
+          onClick={loadOverview}
+          size="small"
+        >
+          Refresh
+        </Button>
+      </Box>
 
 
-        {/* Navigation Tabs */}
-        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
-          <Tabs value={activeTab} onChange={handleTabChange} variant="scrollable" scrollButtons="auto">
-            <Tab 
-              icon={<Dashboard />} 
-              label="Overview" 
-              iconPosition="start"
-            />
-            <Tab 
-              icon={<Analytics />} 
-              label={`Analytics ${overview ? `(${overview.totalBooks} books)` : ''}`}
-              iconPosition="start"
-            />
-            <Tab 
-              icon={<People />} 
-              label={`Users ${overview ? `(${overview.totalUsers})` : ''}`}
-              iconPosition="start"
-            />
-            <Tab 
-              icon={<LocationOn />} 
-              label={`Locations ${overview ? `(${overview.totalLocations})` : ''}`}
-              iconPosition="start"
-            />
-            <Tab 
-              icon={<PersonAdd />} 
-              label="Signup Requests" 
-              iconPosition="start"
-            />
-            <Tab 
-              icon={<Notifications />} 
-              label={`Notifications ${overview?.pendingRequests ? `(${overview.pendingRequests})` : ''}`}
-              iconPosition="start"
-            />
-          </Tabs>
-        </Box>
+      {/* Navigation Tabs */}
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+        <Tabs value={activeTab} onChange={handleTabChange} variant="scrollable" scrollButtons="auto">
+          <Tab 
+            icon={<Dashboard />} 
+            label="Overview" 
+            iconPosition="start"
+          />
+          <Tab 
+            icon={<Analytics />} 
+            label={`Analytics ${overview ? `(${overview.totalBooks} books)` : ''}`}
+            iconPosition="start"
+          />
+          <Tab 
+            icon={<People />} 
+            label={`Users ${overview ? `(${overview.totalUsers})` : ''}`}
+            iconPosition="start"
+          />
+          <Tab 
+            icon={<LocationOn />} 
+            label={`Locations ${overview ? `(${overview.totalLocations})` : ''}`}
+            iconPosition="start"
+          />
+          <Tab 
+            icon={<PersonAdd />} 
+            label="Signup Requests" 
+            iconPosition="start"
+          />
+          <Tab 
+            icon={<Notifications />} 
+            label={`Notifications ${overview?.pendingRequests ? `(${overview.pendingRequests})` : ''}`}
+            iconPosition="start"
+          />
+        </Tabs>
+      </Box>
 
-        {/* Tab Content */}
-        <Box sx={{ mt: 3 }}>
-          {activeTab === 0 && (
-            <Box>
-              <Typography variant="h6" gutterBottom>
-                📊 Dashboard Overview
+      {/* Tab Content */}
+      <Box sx={{ mt: 3, minHeight: '400px', position: 'relative' }}>
+        <Fade in={activeTab === 0} timeout={300}>
+          <Box sx={{ position: activeTab === 0 ? 'relative' : 'absolute', width: '100%', display: activeTab === 0 ? 'block' : 'none' }}>
+            <Typography variant="h6" gutterBottom>
+              📊 Dashboard Overview
+            </Typography>
+            <Typography variant="body1" color="text.secondary" paragraph>
+              Welcome to the LibraryCard admin dashboard. Use the tabs above to navigate between different administrative functions:
+            </Typography>
+            <Box component="ul" sx={{ pl: 2 }}>
+              <Typography component="li" variant="body2" paragraph>
+                <strong>Analytics:</strong> Detailed insights into library usage, popular genres, and user activity
               </Typography>
-              <Typography variant="body1" color="text.secondary" paragraph>
-                Welcome to the LibraryCard admin dashboard. Use the tabs above to navigate between different administrative functions:
+              <Typography component="li" variant="body2" paragraph>
+                <strong>Users:</strong> Manage user accounts, roles, and permissions
               </Typography>
-              <Box component="ul" sx={{ pl: 2 }}>
-                <Typography component="li" variant="body2" paragraph>
-                  <strong>Analytics:</strong> Detailed insights into library usage, popular genres, and user activity
-                </Typography>
-                <Typography component="li" variant="body2" paragraph>
-                  <strong>Users:</strong> Manage user accounts, roles, and permissions
-                </Typography>
-                <Typography component="li" variant="body2" paragraph>
-                  <strong>Locations:</strong> Manage physical locations, shelves, and invitations
-                </Typography>
-                <Typography component="li" variant="body2" paragraph>
-                  <strong>Signup Requests:</strong> Review and approve or deny new user signup requests
-                </Typography>
-                <Typography component="li" variant="body2" paragraph>
-                  <strong>Notifications:</strong> Review pending book removal requests and system notifications
-                </Typography>
-              </Box>
+              <Typography component="li" variant="body2" paragraph>
+                <strong>Locations:</strong> Manage physical locations, shelves, and invitations
+              </Typography>
+              <Typography component="li" variant="body2" paragraph>
+                <strong>Signup Requests:</strong> Review and approve or deny new user signup requests
+              </Typography>
+              <Typography component="li" variant="body2" paragraph>
+                <strong>Notifications:</strong> Review pending book removal requests and system notifications
+              </Typography>
             </Box>
-          )}
+          </Box>
+        </Fade>
 
-          {activeTab === 1 && <AdminAnalytics />}
-          {activeTab === 2 && <AdminUserManager />}
-          {activeTab === 3 && <LocationManager />}
-          {activeTab === 4 && <AdminSignupManager />}
-          {activeTab === 5 && <AdminNotificationCenter />}
-        </Box>
-      </Paper>
-    </Container>
+        <Fade in={activeTab === 1} timeout={300}>
+          <Box sx={{ position: activeTab === 1 ? 'relative' : 'absolute', width: '100%', display: activeTab === 1 ? 'block' : 'none' }}>
+            <AdminAnalytics />
+          </Box>
+        </Fade>
+
+        <Fade in={activeTab === 2} timeout={300}>
+          <Box sx={{ position: activeTab === 2 ? 'relative' : 'absolute', width: '100%', display: activeTab === 2 ? 'block' : 'none' }}>
+            <AdminUserManager />
+          </Box>
+        </Fade>
+
+        <Fade in={activeTab === 3} timeout={300}>
+          <Box sx={{ position: activeTab === 3 ? 'relative' : 'absolute', width: '100%', display: activeTab === 3 ? 'block' : 'none' }}>
+            <LocationManager />
+          </Box>
+        </Fade>
+
+        <Fade in={activeTab === 4} timeout={300}>
+          <Box sx={{ position: activeTab === 4 ? 'relative' : 'absolute', width: '100%', display: activeTab === 4 ? 'block' : 'none' }}>
+            <AdminSignupManager />
+          </Box>
+        </Fade>
+
+        <Fade in={activeTab === 5} timeout={300}>
+          <Box sx={{ position: activeTab === 5 ? 'relative' : 'absolute', width: '100%', display: activeTab === 5 ? 'block' : 'none' }}>
+            <AdminNotificationCenter />
+          </Box>
+        </Fade>
+      </Box>
+    </PageContainer>
   )
 }

--- a/src/components/book/AddBooks.tsx
+++ b/src/components/book/AddBooks.tsx
@@ -2,10 +2,8 @@
 
 import { useEffect, useState, useRef } from 'react'
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
-  Container,
-  Paper,
   Typography,
   Box,
   Chip,
@@ -13,6 +11,7 @@ import {
   Tab,
   CircularProgress,
   Alert,
+  Fade,
 } from '@mui/material'
 import {
   QrCodeScanner,
@@ -36,6 +35,7 @@ import { BookSelectionProvider, useBookSelection } from '@/contexts/BookSelectio
 import CartIndicator from '@/components/library/CartIndicator'
 import BulkReviewModal from '../modals/BulkReviewModal'
 import GenreSelector from './GenreSelector'
+import PageContainer from '../layout/PageContainer'
 import {
   Dialog,
   DialogTitle,
@@ -170,15 +170,25 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
   const { modalState, alert, closeModal } = useModal()
   const { state: selectionState, actions: selectionActions } = useBookSelection()
   const router = useRouter()
+  const searchParams = useSearchParams()
   
-  const [activeTab, setActiveTab] = useState<'scan' | 'search'>(() => {
+  const [activeTab, setActiveTab] = useState(() => {
     // If initialTab is provided (from URL), use that
-    if (initialTab) return initialTab
+    if (initialTab) return initialTab === 'search' ? 0 : 1
     
     // Otherwise, remember user's preferred tab choice
     const savedTab = getStorageItem('addBooks_preferredTab', 'functional') as 'scan' | 'search'
-    return savedTab || 'search'
+    return (savedTab === 'scan') ? 1 : 0
   })
+
+  useEffect(() => {
+    const tabFromUrl = searchParams.get('tab')
+    if (tabFromUrl === 'scan') {
+      setActiveTab(1)
+    } else if (!tabFromUrl) {
+      setActiveTab(0) // Default to search
+    }
+  }, [searchParams])
   
   // Search state
   const [searchQuery, setSearchQuery] = useState('')
@@ -543,7 +553,7 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
       }
       
       // Trigger auto-search when returning to search screen
-      if (activeTab === 'search' || searchQuery.trim()) {
+      if (activeTab === 0 || searchQuery.trim()) {
         setAutoSearchAfterAdd(true)
       }
     } else {
@@ -605,7 +615,7 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
       setIsLoading(false)
 
       // Trigger auto-search when returning to search screen
-      if (activeTab === 'search' || searchQuery.trim()) {
+      if (activeTab === 0 || searchQuery.trim()) {
         setAutoSearchAfterAdd(true)
       }
 
@@ -643,17 +653,29 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
     })
   }
 
-  const handleTabChange = (_event: React.SyntheticEvent, newValue: 'scan' | 'search') => {
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setActiveTab(newValue)
     
-    // Navigate to the appropriate URL
-    router.push(`/add-books/${newValue}`)
+    // Convert number to string for URL and storage
+    const tabName = newValue === 0 ? 'search' : 'scan'
+    
+    // Update URL parameters instead of changing pathname
+    const params = new URLSearchParams(searchParams.toString())
+    
+    if (newValue === 0) {
+      params.delete('tab') // Default tab, no need to set parameter
+    } else {
+      params.set('tab', 'scan')
+    }
+    
+    const newUrl = params.toString() ? `?${params.toString()}` : ''
+    router.replace(`/add-books${newUrl}`, { scroll: false })
     
     // Save user's preferred tab choice
-    setStorageItem('addBooks_preferredTab', newValue, 'functional')
+    setStorageItem('addBooks_preferredTab', tabName, 'functional')
     
     // Clear search query when switching away from search
-    if (newValue !== 'search') {
+    if (newValue !== 0) {
       setSearchQuery('')
     }
   }
@@ -703,8 +725,7 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
   }
 
   return (
-      <Container maxWidth="lg" sx={{ py: 2 }}>
-        <Paper sx={{ p: 3 }}>
+      <PageContainer>
           <Typography variant="h4" component="h2" gutterBottom>
             📚  Add Books
           </Typography>
@@ -719,20 +740,18 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
           )}
 
         {/* Tab Navigation */}
-        <Paper sx={{ mb: 3 }}>
+        <Box sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}>
           <Tabs 
             value={activeTab} 
             onChange={handleTabChange}
             variant="fullWidth"
           >
             <Tab 
-              value="search" 
               label="Search"
               icon={<MenuBook />}
               iconPosition="start"
             />
             <Tab 
-              value="scan" 
               label="Scan ISBN"
               icon={<QrCodeScanner />}
               iconPosition="start"
@@ -746,44 +765,53 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
             />
             */}
           </Tabs>
-        </Paper>
+        </Box>
 
-        {/* ISBN Scanner Tab */}
-        {activeTab === 'scan' && !selectedBook && (
-          <ISBNScanner
-            onISBNDetected={handleISBNDetected}
-            onError={handleError}
-            isLoading={isLoading}
-            disabled={loadingData}
-          />
-        )}
+        {/* Tab Content with Transitions */}
+        {!selectedBook && (
+          <Box sx={{ mt: 3, minHeight: '400px', position: 'relative' }}>
+            {/* Search Tab */}
+            <Fade in={activeTab === 0} timeout={300}>
+              <Box sx={{ position: activeTab === 0 ? 'relative' : 'absolute', width: '100%', display: activeTab === 0 ? 'block' : 'none' }}>
+                <BookSearch
+                  searchQuery={searchQuery}
+                  onSearchQueryChange={setSearchQuery}
+                  onBookSelected={selectBookFromSearch}
+                  onError={handleError}
+                  existingBooks={existingBooks}
+                  justAddedBooks={justAddedBooks}
+                  disabled={loadingData || isLoading}
+                  actionsDisabled={!canAddBooks}
+                  shouldAutoSearch={autoSearchAfterAdd && !preserveSearchState}
+                  onSearchComplete={() => {
+                    setAutoSearchAfterAdd(false)
+                    setPreserveSearchState(false)
+                  }}
+                  displayedResults={searchDisplayedResults}
+                  onDisplayedResultsChange={setSearchDisplayedResults}
+                  lastAddedBookKey={lastAddedBookKey}
+                  cancelledBookKey={cancelledBookKey}
+                  onCancelledBookScrollComplete={() => setCancelledBookKey(null)}
+                  searchResults={searchResults}
+                  onSearchResultsChange={setSearchResults}
+                  totalResults={searchTotalResults}
+                  onTotalResultsChange={setSearchTotalResults}
+                />
+              </Box>
+            </Fade>
 
-        {/* Search Tab */}
-        {activeTab === 'search' && !selectedBook && (
-          <BookSearch
-            searchQuery={searchQuery}
-            onSearchQueryChange={setSearchQuery}
-            onBookSelected={selectBookFromSearch}
-            onError={handleError}
-            existingBooks={existingBooks}
-            justAddedBooks={justAddedBooks}
-            disabled={loadingData || isLoading}
-            actionsDisabled={!canAddBooks}
-            shouldAutoSearch={autoSearchAfterAdd && !preserveSearchState}
-            onSearchComplete={() => {
-              setAutoSearchAfterAdd(false)
-              setPreserveSearchState(false)
-            }}
-            displayedResults={searchDisplayedResults}
-            onDisplayedResultsChange={setSearchDisplayedResults}
-            lastAddedBookKey={lastAddedBookKey}
-            cancelledBookKey={cancelledBookKey}
-            onCancelledBookScrollComplete={() => setCancelledBookKey(null)}
-            searchResults={searchResults}
-            onSearchResultsChange={setSearchResults}
-            totalResults={searchTotalResults}
-            onTotalResultsChange={setSearchTotalResults}
-          />
+            {/* ISBN Scanner Tab */}
+            <Fade in={activeTab === 1} timeout={300}>
+              <Box sx={{ position: activeTab === 1 ? 'relative' : 'absolute', width: '100%', display: activeTab === 1 ? 'block' : 'none' }}>
+                <ISBNScanner
+                  onISBNDetected={handleISBNDetected}
+                  onError={handleError}
+                  isLoading={isLoading}
+                  disabled={loadingData}
+                />
+              </Box>
+            </Fade>
+          </Box>
         )}
 
 
@@ -914,8 +942,7 @@ function AddBooksInternal({ initialTab }: AddBooksInternalProps) {
         <CartIndicator 
           onViewSelection={() => setShowBulkReviewModal(true)}
         />
-        </Paper>
-      </Container>
+      </PageContainer>
   )
 }
 

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+import { Container, Paper, Fade, Box } from '@mui/material'
+
+interface PageContainerProps {
+  children: React.ReactNode
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  padding?: number
+}
+
+export default function PageContainer({ 
+  children, 
+  maxWidth = 'xl', 
+  padding = 3 
+}: PageContainerProps) {
+  const pathname = usePathname()
+  const [displayChildren, setDisplayChildren] = useState(children)
+  const [fadeIn, setFadeIn] = useState(true)
+  const prevPathnameRef = useRef(pathname)
+
+  useEffect(() => {
+    // Only trigger fade if pathname actually changed (for main navigation)
+    if (prevPathnameRef.current !== pathname) {
+      prevPathnameRef.current = pathname
+      setFadeIn(false)
+      
+      const timer = setTimeout(() => {
+        setDisplayChildren(children)
+        setFadeIn(true)
+      }, 150)
+      
+      return () => clearTimeout(timer)
+    } else {
+      // If pathname didn't change, just update children directly
+      setDisplayChildren(children)
+      setFadeIn(true)
+    }
+  }, [pathname, children])
+
+  return (
+    <Container maxWidth={maxWidth} sx={{ py: 2 }}>
+      <Paper sx={{ p: padding }}>
+        <Fade in={fadeIn} timeout={{ enter: 300, exit: 150 }}>
+          <Box sx={{ minHeight: '400px' }}>
+            {displayChildren}
+          </Box>
+        </Fade>
+      </Paper>
+    </Container>
+  )
+}

--- a/src/components/library/BookLibrary.tsx
+++ b/src/components/library/BookLibrary.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import { Container, Paper, Alert, Typography, Box, CircularProgress } from '@mui/material'
+import { Alert, Typography, Box, CircularProgress } from '@mui/material'
 import type { EnhancedBook } from '@/lib/types'
 import { useModal } from '@/hooks/useModal'
 import { useBookLibrary } from '@/hooks/useBookLibrary'
@@ -22,6 +22,7 @@ import ActiveFilters from './ActiveFilters'
 import ShelfTiles from './ShelfTiles'
 import ViewModeControls from './ViewModeControls'
 import BookViews from './BookViews'
+import PageContainer from '../layout/PageContainer'
 
 interface BookLibraryProps {
   initialFilters?: {
@@ -289,25 +290,22 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
   // Show loading screen while data is being fetched
   if (isLoading) {
     return (
-      <Container maxWidth="xl" sx={{ py: 2 }}>
-        <Paper sx={{ p: 3 }}>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8 }}>
-            <CircularProgress size={60} sx={{ mb: 3 }} />
-            <Typography variant="h5" component="h2" gutterBottom>
-              📚 Loading Your Library
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', maxWidth: 400 }}>
-              Please wait while we fetch your books, shelves, and settings...
-            </Typography>
-          </Box>
-        </Paper>
-      </Container>
+      <PageContainer>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8 }}>
+          <CircularProgress size={60} sx={{ mb: 3 }} />
+          <Typography variant="h5" component="h2" gutterBottom>
+            📚 Loading Your Library
+          </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ textAlign: 'center', maxWidth: 400 }}>
+            Please wait while we fetch your books, shelves, and settings...
+          </Typography>
+        </Box>
+      </PageContainer>
     )
   }
 
   return (
-    <Container maxWidth="xl" sx={{ py: 2 }}>
-      <Paper sx={{ p: 3 }}>
+    <PageContainer>
         <LibraryHeader
           userRole={userRole}
           currentLocation={currentLocation}
@@ -533,7 +531,6 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
             open={true}
           />
         )}
-      </Paper>
-    </Container>
+    </PageContainer>
   )
 }


### PR DESCRIPTION
## Summary
- Fixed Add Books tab switching by converting from pathname-based routing to URL parameters
- Added smooth Fade transitions that match admin subtab behavior 
- Created unified PageContainer component for consistent layouts across all main pages
- Only tab content transitions now, not headers or navigation elements

## Changes Made
- **Routing Fix**: Converted Add Books from `/add-books/search` ↔ `/add-books/scan` pathname changes to URL parameters (`/add-books` ↔ `/add-books?tab=scan`)
- **Smooth Transitions**: Added 300ms Fade transitions for tab content using absolute positioning
- **Backward Compatibility**: Old URLs now redirect to new parameter-based format
- **Unified Layout**: Created PageContainer component used by Library, Add Books, and Admin pages
- **Consistent Behavior**: Tab switching now matches admin dashboard pattern exactly

## Technical Details
- **PageContainer**: New component handles consistent page fade transitions triggered only by pathname changes
- **URL Parameters**: Admin and Add Books both use `useSearchParams()` and `router.replace()` for tab state
- **Transition Logic**: Fade transitions use absolute positioning to prevent layout shifts during tab changes
- **Material UI Tabs**: Fixed activeTab to use numeric indices (0, 1) instead of string values

## Test Plan
- [x] Click "Add Books" in main navigation - shows search tab by default
- [x] Switch between Search and Scan ISBN tabs - smooth content transitions
- [x] Verify headers and tab navigation don't fade during subtab transitions  
- [x] Test old bookmarked URLs redirect properly
- [x] Build and lint verification passed

🤖 Generated with [Claude Code](https://claude.ai/code)