### PR TITLE
Improve mobile layout and UX in AddBooks workflow

### DIFF
--- a/src/components/book/AddBooks.tsx
+++ b/src/components/book/AddBooks.tsx
@@ -732,8 +732,8 @@ try {
   }
 
   return (
-    <Container maxWidth="xl" sx={{ py: 2 }}>
-      <Paper sx={{ p: 3 }}>
+    <Container maxWidth="xl" sx={{ py: { xs: 1, sm: 2 } }}>
+      <Paper sx={{ p: { xs: 2, sm: 3 } }}>
         <Typography variant="h4" component="h2" gutterBottom>
           📚  Add Books
         </Typography>
@@ -826,7 +826,7 @@ try {
 
         {/* Selected Book Display (shared between tabs) */}
         {selectedBook && (
-          <Box sx={{ mt: 3 }} data-testid="book-selected-section" ref={bookSelectedRef}>
+          <Box sx={{ mt: { xs: 2, sm: 3 } }} data-testid="book-selected-section" ref={bookSelectedRef}>
             <BookPreview
               book={selectedBook}
               customTags={customTags}
@@ -863,7 +863,7 @@ try {
             />
             
             {/* Shelf selector */}
-            <Box sx={{ mt: 3, mb: 2 }}>
+            <Box sx={{ mt: { xs: 2, sm: 3 }, mb: { xs: 1.5, sm: 2 } }}>
               <ShelfSelector
                 shelves={allShelves}
                 locations={locations}
@@ -874,7 +874,19 @@ try {
             </Box>
 
             {/* Action buttons */}
-            <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+            <Box sx={{ 
+              display: 'flex', 
+              gap: 1, 
+              mt: 2,
+              position: { xs: 'sticky', sm: 'static' },
+              bottom: { xs: 0, sm: 'auto' },
+              bgcolor: { xs: 'background.paper', sm: 'transparent' },
+              p: { xs: 2, sm: 0 },
+              mx: { xs: -2, sm: 0 },
+              borderTop: { xs: '1px solid', sm: 'none' },
+              borderColor: { xs: 'divider', sm: 'transparent' },
+              zIndex: { xs: 1, sm: 'auto' }
+            }}>
               <Button 
                 variant="contained"
                 startIcon={isLoading ? <CircularProgress size={16} color="inherit" /> : <Save />}

--- a/src/components/book/BookGrid.tsx
+++ b/src/components/book/BookGrid.tsx
@@ -149,14 +149,12 @@ export default function BookGrid({
                 </Typography>
                 {book.series && (
                   <Typography variant="body2" color="text.secondary" gutterBottom>
-                    <strong>Series:</strong> 
                     <Typography 
                       component="span" 
                       sx={{ 
                         color: 'primary.main', 
                         cursor: 'pointer',
                         textDecoration: 'underline',
-                        ml: 0.5,
                         '&:hover': { textDecoration: 'none' }
                       }}
                       onClick={() => onSeriesClick(book.series!)}

--- a/src/components/book/BookPreview.tsx
+++ b/src/components/book/BookPreview.tsx
@@ -12,12 +12,13 @@ import {
   Chip,
   Alert,
   CircularProgress,
+  useTheme,
+  useMediaQuery,
 } from '@mui/material'
 import {
   Save,
   Cancel,
   Info,
-  Image,
 } from '@mui/icons-material'
 import type { EnhancedBook } from '@/lib/types'
 import CoverSelectionModal from '../modals/CoverSelectionModal'
@@ -61,6 +62,8 @@ export default function BookPreview({
 }: BookPreviewProps) {
   const [tagsError, setTagsError] = useState<string>('')
   const [showCoverSelection, setShowCoverSelection] = useState(false)
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'))
 
   const handleTagsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -106,33 +109,47 @@ export default function BookPreview({
         </Alert>
       )}
       
-      <Card sx={{ mb: 3 }}>
+      <Card sx={{ mb: { xs: 2, sm: 3 } }}>
         <CardContent>
-          <Box sx={{ display: 'flex', gap: 2 }}>
+          <Box sx={{ display: 'flex', gap: { xs: 1.5, sm: 2 }, flexDirection: 'row', alignItems: 'flex-start' }}>
             <Box sx={{ position: 'relative' }}>
-              {book.thumbnail && (
+              {book.thumbnail ? (
                 <CardMedia
                   component="img"
                   src={book.thumbnail}
                   alt={book.title}
-                  sx={{ width: 120, height: 'auto', objectFit: 'contain' }}
-                />
-              )}
-              {canSelectCover && (
-                <Button
-                  size="small"
-                  variant="outlined"
-                  startIcon={<Image />}
-                  onClick={() => setShowCoverSelection(true)}
                   sx={{ 
-                    mt: 1, 
-                    width: 120,
-                    fontSize: '0.75rem',
-                    py: 0.5
+                    width: { xs: 100, sm: 120 }, 
+                    height: 'auto', 
+                    objectFit: 'contain',
+                    cursor: canSelectCover ? 'pointer' : 'default',
+                    borderRadius: 1,
+                    '&:hover': canSelectCover ? {
+                      opacity: 0.8,
+                      transform: 'scale(1.02)'
+                    } : {}
                   }}
+                  onClick={() => canSelectCover && setShowCoverSelection(true)}
+                />
+              ) : (
+                <Box 
+                  sx={{ 
+                    width: { xs: 100, sm: 120 }, 
+                    height: 150, 
+                    bgcolor: 'grey.200',
+                    borderRadius: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: canSelectCover ? 'pointer' : 'default',
+                    '&:hover': canSelectCover ? {
+                      bgcolor: 'grey.300'
+                    } : {}
+                  }}
+                  onClick={() => canSelectCover && setShowCoverSelection(true)}
                 >
-                  Choose Cover
-                </Button>
+                  <Typography variant="h4" color="text.secondary">📖</Typography>
+                </Box>
               )}
             </Box>
             <Box sx={{ flex: 1 }}>
@@ -141,7 +158,7 @@ export default function BookPreview({
               </Typography>
               
               <Typography variant="body2" color="text.secondary" gutterBottom>
-                <strong>Authors:</strong> {book.authors.map((author, index) => (
+                {book.authors.map((author, index) => (
                   <span key={index}>
                     <Typography 
                       component="span" 
@@ -158,28 +175,21 @@ export default function BookPreview({
                     {index < book.authors.length - 1 && ', '}
                   </span>
                 ))}
+                {book.publishedDate && (
+                  <Typography component="span" color="text.secondary">
+                    , {new Date(book.publishedDate).getFullYear()}
+                  </Typography>
+                )}
               </Typography>
-              
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                <strong>ISBN:</strong> {book.isbn}
-              </Typography>
-              
-              {book.publishedDate && (
-                <Typography variant="body2" color="text.secondary" gutterBottom>
-                  <strong>Published:</strong> {book.publishedDate}
-                </Typography>
-              )}
               
               {book.series && (
                 <Typography variant="body2" color="text.secondary" gutterBottom>
-                  <strong>Series:</strong>
                   <Typography 
                     component="span" 
                     sx={{ 
                       color: 'primary.main', 
                       cursor: 'pointer',
                       textDecoration: 'underline',
-                      ml: 0.5,
                       '&:hover': { textDecoration: 'none' }
                     }}
                     onClick={() => onSeriesClick(book.series!)}
@@ -193,9 +203,6 @@ export default function BookPreview({
               {/* Enhanced genres with fallback to categories */}
               {(book.enhancedGenres || book.categories) && (
                 <Box sx={{ mt: 1, mb: 1 }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
-                    <strong>Genres:</strong>
-                  </Typography>
                   {(book.enhancedGenres || book.categories || []).slice(0, 4).map((genre, index) => (
                     <Chip 
                       key={index} 
@@ -226,8 +233,8 @@ export default function BookPreview({
               
               {book.description && (
                 <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                  {book.description.substring(0, 200)}
-                  {book.description.length > 200 && '...'}
+                  {book.description.substring(0, isSmallScreen ? 100 : 200)}
+                  {book.description.length > (isSmallScreen ? 100 : 200) && '...'}
                 </Typography>
               )}
               
@@ -251,7 +258,7 @@ export default function BookPreview({
       </Card>
 
       {/* Tags input */}
-      <Box sx={{ mb: 2 }}>
+      <Box sx={{ mb: { xs: 1.5, sm: 2 } }}>
         <TextField
           fullWidth
           size="small"

--- a/src/components/book/GenreSelector.tsx
+++ b/src/components/book/GenreSelector.tsx
@@ -10,9 +10,8 @@ import {
   Autocomplete,
   TextField,
   Button,
-  Paper,
-  Divider,
   CircularProgress,
+  FormControl,
 } from '@mui/material'
 import {
   Add,
@@ -129,17 +128,11 @@ export default function GenreSelector({
   }
 
   return (
-    <Paper sx={{ p: 2, mt: 2 }}>
-      <Typography variant="h6" gutterBottom>
-        📚 Select Genres
-      </Typography>
+    <Box sx={{ mt: 2 }}>
       
       {/* Auto-Suggested Genres */}
       {remainingSuggestions.length > 0 && (
         <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-            Suggested based on book classification:
-          </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
             {remainingSuggestions.map(genre => (
               <Box key={genre.id} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
@@ -194,65 +187,58 @@ export default function GenreSelector({
         </Box>
       )}
 
-      {(remainingSuggestions.length > 0 || selectedGenres.length > 0) && (
-        <Divider sx={{ my: 2 }} />
-      )}
-
       {/* Add Custom Genre */}
       <Box>
-        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          Add more genres:
-        </Typography>
-        <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-end' }}>
-          <Autocomplete
-            value={autocompleteValue}
-            onChange={(_, newValue) => setAutocompleteValue(newValue)}
-            options={availableForAutocomplete}
-            getOptionLabel={(option) => option.name}
-            renderOption={(props, option) => (
-              <li {...props}>
-                <Box>
-                  <Typography variant="body2">{option.name}</Typography>
-                  {option.description && (
-                    <Typography variant="caption" color="text.secondary">
-                      {option.description}
-                    </Typography>
-                  )}
-                </Box>
-              </li>
-            )}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Search genres"
-                variant="outlined"
-                size="small"
-                placeholder="Type to search..."
-              />
-            )}
-            sx={{ flexGrow: 1, minWidth: 200 }}
-            ListboxProps={{
-              style: { maxHeight: 200 }
-            }}
-          />
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'stretch' }}>
+          <FormControl fullWidth size="small">
+            <Autocomplete
+              value={autocompleteValue}
+              onChange={(_, newValue) => setAutocompleteValue(newValue)}
+              options={availableForAutocomplete}
+              getOptionLabel={(option) => option.name}
+              renderOption={(props, option) => (
+                <li {...props}>
+                  <Box>
+                    <Typography variant="body2">{option.name}</Typography>
+                    {option.description && (
+                      <Typography variant="caption" color="text.secondary">
+                        {option.description}
+                      </Typography>
+                    )}
+                  </Box>
+                </li>
+              )}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Add Genres"
+                  variant="outlined"
+                  size="small"
+                  placeholder="Type to search..."
+                />
+              )}
+              sx={{ flexGrow: 1, minWidth: 200 }}
+              ListboxProps={{
+                style: { maxHeight: 200 }
+              }}
+            />
+          </FormControl>
           <Button
             variant="contained"
             size="small"
             startIcon={<Add />}
             onClick={handleAddFromAutocomplete}
             disabled={!autocompleteValue}
-            sx={{ whiteSpace: 'nowrap' }}
+            sx={{ 
+              whiteSpace: 'nowrap',
+              height: '40px' // Match the height of small TextField
+            }}
           >
             Add Genre
           </Button>
         </Box>
       </Box>
 
-      {selectedGenres.length === 0 && remainingSuggestions.length === 0 && (
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, fontStyle: 'italic' }}>
-          No genre suggestions available. You can search and add genres manually above.
-        </Typography>
-      )}
-    </Paper>
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- Optimize BookPreview layout for mobile screens with consistent row direction and top alignment
- Remove redundant UI labels and improve visual hierarchy throughout book displays
- Implement responsive description truncation (100 chars mobile, 200 desktop)  
- Add click-to-select cover functionality with visual feedback instead of separate button
- Update GenreSelector with consistent Material-UI labeling and proper button height alignment
- Add sticky action buttons on mobile for better accessibility
- Reduce padding/margins for improved mobile space utilization

## Test plan
- [x] Verify mobile layout improvements in AddBooks workflow
- [x] Test cover click functionality works correctly
- [x] Confirm genre selector labeling matches shelf selector
- [x] Check responsive description truncation on different screen sizes
- [x] Verify sticky action buttons work on mobile
- [x] Run build verification to ensure no TypeScript errors

Addresses GitHub issue #103

🤖 Generated with [Claude Code](https://claude.ai/code)