### PR TITLE
Fix pagination reset when changing book covers from page 2+

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -4,6 +4,14 @@ This file documents all completed features, fixes, and improvements to the Libra
 
 ## July 27, 2025 - Local Development Environment Improvements & Library UI Mobile Optimization
 
+### Pagination State Preservation During Book Updates - GitHub Issue #118 COMPLETE!
+- **FIXED**: Pagination reset issue where changing book covers on page 2+ would incorrectly return user to page 1
+- **SEPARATED**: Filter/sort pagination reset logic from book data update logic to preserve user's current page
+- **ENHANCED**: Pagination validation to gracefully handle edge cases where current page exceeds available pages
+- **IMPROVED**: User experience by maintaining pagination state during cover selection, ratings, genre updates, and other book modifications
+- **PRESERVED**: Existing pagination reset behavior when filters or sorting criteria actually change
+- **VERIFIED**: Fix works across all book view modes (card, compact, list) and all book update operations
+
 ### Local Onboarding Enhancement - GitHub Issue #88 COMPLETE!
 - **UPDATED**: `.env.example` with comprehensive environment variable examples including local development user credentials
 - **IMPLEMENTED**: Robust genre seeding system with 45 curated genres (25 fiction + 20 non-fiction) using proper foreign key relationships

--- a/docs/reference/TODO.md
+++ b/docs/reference/TODO.md
@@ -6,6 +6,14 @@ This file tracks active development tasks and future enhancements for the Librar
 
 ## ✅ Recently Completed (July 2025)
 
+### Pagination State Preservation During Book Updates - GitHub Issue #118 - COMPLETE!
+- [x] **Root Cause Identification**: Identified pagination reset issue in `useBookFilters.ts` where book data changes triggered pagination reset
+- [x] **Logic Separation**: Separated filter/sort pagination reset from book data update pagination preservation
+- [x] **Enhanced Validation**: Added safeguard to prevent current page from exceeding available pages after book updates
+- [x] **Comprehensive Testing**: Verified fix works across all book view modes and update operations (covers, ratings, genres, checkout)
+- [x] **User Experience**: Preserved pagination state during book modifications while maintaining filter-based reset behavior
+- [x] **Edge Case Handling**: Graceful handling of pagination when filtered results change due to book updates
+
 ### Local Development Environment Enhancement - GitHub Issue #88 - COMPLETE!
 - [x] **Environment Variable Template**: Updated `.env.example` with comprehensive examples including local development user credentials
 - [x] **Genre Seeding System**: Implemented robust 45-genre seeding system (25 fiction + 20 non-fiction) with proper foreign key relationships

--- a/src/hooks/useBookFilters.ts
+++ b/src/hooks/useBookFilters.ts
@@ -466,9 +466,22 @@ export function useBookFilters({
     })
 
     setFilteredBooks(filtered)
-    // Reset to first page when filters or sorting change
-    setCurrentPage(1)
   }, [books, searchTerm, shelfFilter, categoryFilter, locationFilter, checkoutFilter, authorFilter, userRole, shelves, allLocations, userLocations, currentLocation, sortField, sortDirection])
+
+  // Separate effect to reset pagination only when filter criteria change (not when book data changes)
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [searchTerm, shelfFilter, categoryFilter, locationFilter, checkoutFilter, authorFilter, sortField, sortDirection])
+
+  // Ensure current page is valid when filtered books change (but don't reset unnecessarily)
+  useEffect(() => {
+    if (filteredBooks.length > 0) {
+      const maxPage = Math.ceil(filteredBooks.length / booksPerPage)
+      if (currentPage > maxPage) {
+        setCurrentPage(maxPage)
+      }
+    }
+  }, [filteredBooks.length, booksPerPage, currentPage])
 
   // Pagination functions
   const getPaginatedBooks = (books: EnhancedBook[]) => {


### PR DESCRIPTION
## Summary
- Fixed pagination reset issue where users on page 2+ would be returned to page 1 after changing book covers
- Separated filter/sort pagination reset logic from book data update logic to preserve current page during book modifications
- Added pagination validation to gracefully handle edge cases where current page exceeds available pages
- Maintained existing pagination reset behavior when filters or sorting criteria actually change
- Verified fix works across all book view modes (card, compact, list) and all book update operations

## Technical Details
The issue was in `useBookFilters.ts` where a single `useEffect` handled both filtering/sorting and pagination reset. When a book cover was changed, the books array was updated, triggering the effect and resetting pagination to page 1.

**Solution**: Split the logic into two separate `useEffect` hooks:
1. **Filtering/Sorting Effect**: Handles book filtering and sorting without pagination reset
2. **Pagination Reset Effect**: Only resets pagination when filter criteria (not book data) changes
3. **Pagination Validation Effect**: Ensures current page doesn't exceed available pages after updates

## Test plan
- [x] Verify cover selection from page 2+ maintains current page
- [x] Confirm pagination still resets when filters change (search, shelf, genre, etc.)
- [x] Test edge case handling when filtered results change
- [x] Validate fix works across all book view modes
- [x] Ensure all book update operations (ratings, genres, checkout) preserve pagination
- [x] Build and lint verification passed

🤖 Generated with [Claude Code](https://claude.ai/code)