### PR TITLE
Fix location deletion foreign key constraint error

### DIFF
--- a/workers/locations/index.ts
+++ b/workers/locations/index.ts
@@ -204,10 +204,23 @@ export async function deleteLocation(userId: string, env: Env, corsHeaders: Reco
     });
   }
 
-  // Delete associated shelves and books first (cascading delete)
+  // Delete associated data in correct order to avoid foreign key constraint violations
+  // 1. Delete books first (they reference shelves)
   await env.DB.prepare('DELETE FROM books WHERE shelf_id IN (SELECT id FROM shelves WHERE location_id = ?)').bind(id).run();
+  
+  // 2. Delete shelves (they reference locations)
   await env.DB.prepare('DELETE FROM shelves WHERE location_id = ?').bind(id).run();
+  
+  // 3. Delete location-specific permission and capability data
+  await env.DB.prepare('DELETE FROM location_user_permissions WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_admin_capabilities WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_default_permissions WHERE location_id = ?').bind(id).run();
+  
+  // 4. Delete location membership and invitation data
   await env.DB.prepare('DELETE FROM location_members WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_invitations WHERE location_id = ?').bind(id).run();
+  
+  // 5. Finally delete the location itself
   await env.DB.prepare('DELETE FROM locations WHERE id = ?').bind(id).run();
 
   return new Response(JSON.stringify({ success: true }), {


### PR DESCRIPTION
## Summary

Fixes location deletion failure when locations have permission/capability data.

**Resolves**: #137

## Problem

Location deletion was failing with `FOREIGN KEY constraint failed: SQLITE_CONSTRAINT` for locations with permission data. The `deleteLocation` function wasn't cleaning up all tables that reference `location_id`.

## Solution

Updated deletion order to properly cascade delete all related data:

1. ✅ Books (reference shelves) 
2. ✅ Shelves (reference locations)
3. 🆕 **Location permissions & capabilities** - Added cleanup
4. 🆕 **Location membership & invitations** - Enhanced cleanup  
5. ✅ Location itself

## Changes

**File**: `workers/locations/index.ts`
- Added deletion of `location_user_permissions`
- Added deletion of `location_admin_capabilities` 
- Added deletion of `location_default_permissions`
- Added deletion of `location_invitations`
- Documented deletion order with comments

## Testing

- [x] Code review completed
- [ ] Production deployment via enhanced safety workflow
- [ ] Verify Anthony's Library deletion works
- [ ] Verify other locations still delete properly

## Deployment Plan

Using enhanced production deployment workflow:
1. Merge to main
2. Deploy via GitHub Actions enhanced safety workflow
3. Test location deletion functionality
4. Monitor for any issues

## Impact

- **Risk**: Low - only adds more thorough cleanup
- **Scope**: Fixes blocked admin functionality  
- **Rollback**: Standard database restore if needed