### PR TITLE
Fix location deletion and creation permission controls (GitHub issue #147)

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## July 30, 2025 - Location Permission Security Fixes
+
+### Location Creation & Permission UI Fixes - GitHub Issue #147 COMPLETE!
+- **RESTRICTED**: Location creation buttons to super admins only (removed from regular admin access)
+- **UPDATED**: All UI messaging to clearly distinguish between "super administrators" and "location administrators"  
+- **FIXED**: Location creation automatic form display logic to only trigger for super admins
+- **ENHANCED**: Permission management messages to guide users to appropriate contact (super admin vs location admin)
+- **SECURED**: Frontend permission boundaries to match backend security model where only super admins can create locations
+- **CLARIFIED**: User guidance throughout application for who to contact based on needed capability type
+
+### UI Message Consistency Improvements
+- **UPDATED**: HelpModal messaging to specify "super administrator" for location setup requests
+- **MAINTAINED**: Correct "location administrator" references for location-specific permissions (book editing, genres, etc.)
+- **IMPROVED**: LocationPermissionManager alerts to clearly indicate super admin vs location admin capabilities
+- **STANDARDIZED**: Permission messaging across all components for consistent user experience
+
 ## July 29, 2025 - Enhanced Location Management & Default Permissions System
 
 ### Enhanced Location Management with Default Permissions - GitHub Issues #88 & #127 COMPLETE!

--- a/src/components/admin/LocationManager.tsx
+++ b/src/components/admin/LocationManager.tsx
@@ -142,7 +142,7 @@ export default function LocationManager() {
         // Check permissions for each location
         await checkAllLocationPermissions(data)
         
-        if (data.length === 0 && isAdmin(userRole)) {
+        if (data.length === 0 && userRole === 'super_admin') {
           setShowCreateForm(true)
         } else {
           setSelectedLocation(data[0])
@@ -555,12 +555,12 @@ export default function LocationManager() {
       {locations.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '2rem' }}>
           <p style={{ marginBottom: '1rem', color: '#666' }}>
-            {isAdmin(userRole) 
+            {userRole === 'super_admin'
               ? "You don't have any locations yet. Create your first location to start organizing your books!"
-              : "No locations are available. Contact an administrator to create locations."
+              : "No locations are available. Contact a super administrator to create locations."
             }
           </p>
-          {isAdmin(userRole) && (
+          {userRole === 'super_admin' && (
             <Button 
               variant="contained"
               startIcon={<Add />}
@@ -575,7 +575,7 @@ export default function LocationManager() {
           <div style={{ marginBottom: '2rem' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
               <h3>Your Locations</h3>
-              {isAdmin(userRole) && (
+              {userRole === 'super_admin' && (
                 <Button 
                   variant="contained"
                   startIcon={<Add />}
@@ -709,17 +709,19 @@ export default function LocationManager() {
                                 <Edit />
                               </IconButton>
                             )}
-                            <IconButton
-                              edge="end"
-                              onClick={(e) => {
-                                e.stopPropagation()
-                                deleteLocation(location.id, location.name)
-                              }}
-                              size="small"
-                              color="error"
-                            >
-                              <Delete />
-                            </IconButton>
+                            {(userRole === 'super_admin' || location.owner_id === session?.user?.email) && (
+                              <IconButton
+                                edge="end"
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  deleteLocation(location.id, location.name)
+                                }}
+                                size="small"
+                                color="error"
+                              >
+                                <Delete />
+                              </IconButton>
+                            )}
                           </Box>
                         </ListItemSecondaryAction>
                       )}

--- a/src/components/admin/LocationPermissionManager.tsx
+++ b/src/components/admin/LocationPermissionManager.tsx
@@ -372,7 +372,7 @@ export default function LocationPermissionManager({ locationId, locationName, us
 
       {!canManagePermissions && (
         <Alert severity="info" sx={{ mb: 2 }}>
-          You can view permissions but cannot modify them. Only super administrators or location admins with &quot;Control User Permissions&quot; capability can make changes.
+          You can view permissions but cannot modify them. Contact the super administrator or another location admin with &quot;Control User Permissions&quot; capability to make changes.
         </Alert>
       )}
 
@@ -747,7 +747,7 @@ export default function LocationPermissionManager({ locationId, locationName, us
 
               {!canManagePermissions && (
                 <Alert severity="info" sx={{ mt: 2 }}>
-                  You can view default permissions but cannot modify them. Only super administrators or location admins with "Control User Permissions" capability can make changes.
+                  You can view default permissions but cannot modify them. Contact a super administrators or another location admin with "Control User Permissions" capability to make changes.
                 </Alert>
               )}
             </>

--- a/src/components/modals/HelpModal.tsx
+++ b/src/components/modals/HelpModal.tsx
@@ -235,7 +235,7 @@ export default function HelpModal({ open, onClose }: HelpModalProps) {
 
                   {!userIsAdmin && (
                     <Alert severity="info" sx={{ mt: 2 }}>
-                      If you don&apos;t have any locations available, contact an administrator to set up locations and shelves.
+                      If you don&apos;t have any locations available, contact a super administrator to set up locations and shelves.
                     </Alert>
                   )}
                 </AccordionDetails>

--- a/workers/locations/index.ts
+++ b/workers/locations/index.ts
@@ -196,12 +196,22 @@ export async function updateLocation(request: Request, userId: string, env: Env,
 }
 
 export async function deleteLocation(userId: string, env: Env, corsHeaders: Record<string, string>, id: number) {
-  // Check if user is super admin (only super admins can delete locations)
-  if (!(await isUserSuperAdmin(userId, env))) {
-    return new Response(JSON.stringify({ error: 'Super admin privileges required to delete locations' }), {
-      status: 403,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+  // Check if user can delete this location:
+  // 1. Super admins can delete any location
+  // 2. Regular admins can only delete locations they created themselves
+  const isSuperAdmin = await isUserSuperAdmin(userId, env);
+  
+  if (!isSuperAdmin) {
+    // Check if user is the owner of this location
+    const ownerStmt = env.DB.prepare('SELECT owner_id FROM locations WHERE id = ?');
+    const ownerResult = await ownerStmt.bind(id).first() as any;
+    
+    if (!ownerResult || ownerResult.owner_id !== userId) {
+      return new Response(JSON.stringify({ error: 'You can only delete locations you created yourself' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
   }
 
   // Delete associated data in correct order to avoid foreign key constraint violations


### PR DESCRIPTION
## Summary
- Enhanced backend permission validation in workers/locations/index.ts to properly check ownership for regular admins
- Updated frontend UI in LocationManager.tsx to hide delete buttons from non-owners 
- Corrected location creation restrictions to super admins only throughout the application
- Improved permission messaging in LocationPermissionManager and HelpModal for clarity

## Test plan
- [ ] Verify regular admins cannot see create location buttons
- [ ] Verify regular admins can only delete locations they own
- [ ] Verify super admins can create and delete any location
- [ ] Test permission messaging is clear and consistent
- [ ] Confirm backend API properly validates ownership for location operations

🤖 Generated with [Claude Code](https://claude.ai/code)