### PR TITLE
Fix location deletion foreign key constraint error

### DIFF
--- a/workers/locations/index.ts
+++ b/workers/locations/index.ts
@@ -204,10 +204,23 @@ export async function deleteLocation(userId: string, env: Env, corsHeaders: Reco
     });
   }
 
-  // Delete associated shelves and books first (cascading delete)
+  // Delete associated data in correct order to avoid foreign key constraint violations
+  // 1. Delete books first (they reference shelves)
   await env.DB.prepare('DELETE FROM books WHERE shelf_id IN (SELECT id FROM shelves WHERE location_id = ?)').bind(id).run();
+  
+  // 2. Delete shelves (they reference locations)
   await env.DB.prepare('DELETE FROM shelves WHERE location_id = ?').bind(id).run();
+  
+  // 3. Delete location-specific permission and capability data
+  await env.DB.prepare('DELETE FROM location_user_permissions WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_admin_capabilities WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_default_permissions WHERE location_id = ?').bind(id).run();
+  
+  // 4. Delete location membership and invitation data
   await env.DB.prepare('DELETE FROM location_members WHERE location_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM location_invitations WHERE location_id = ?').bind(id).run();
+  
+  // 5. Finally delete the location itself
   await env.DB.prepare('DELETE FROM locations WHERE id = ?').bind(id).run();
 
   return new Response(JSON.stringify({ success: true }), {


### PR DESCRIPTION
- Add proper cascading deletion for location permission tables
- Clean up location_user_permissions before deleting location
- Clean up location_admin_capabilities before deleting location
- Clean up location_default_permissions before deleting location
- Clean up location_invitations before deleting location
- Ensures proper deletion order to respect foreign key constraints

Fixes #137: Anthony's Library and other locations with permission data can now be deleted without foreign key constraint violations