### PR TITLE
Fix crypto module build error by switching to browser-compatible OTP …

### DIFF
--- a/workers/auth/totp.ts
+++ b/workers/auth/totp.ts
@@ -1,4 +1,4 @@
-import { authenticator } from '@otplib/preset-default';
+import { authenticator } from '@otplib/preset-browser';
 import { hash, compare } from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import * as QRCode from 'qrcode';


### PR DESCRIPTION
…library

Changed @otplib/preset-default to @otplib/preset-browser to resolve Cloudflare Workers build failure where Node.js crypto module was not available.

🤖 Generated with [Claude Code](https://claude.ai/code)