### PR TITLE
Add @otplib/preset-browser dependency for Cloudflare Workers compatib…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@marsidev/react-turnstile": "^1.1.0",
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
+        "@otplib/preset-browser": "^12.0.1",
         "@otplib/preset-default": "^12.0.1",
         "@types/bcryptjs": "^3.0.0",
         "@types/nodemailer": "^6.4.17",
@@ -969,6 +970,11 @@
         "@otplib/core": "^12.0.1",
         "thirty-two": "^1.0.2"
       }
+    },
+    "node_modules/@otplib/preset-browser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-browser/-/preset-browser-12.0.1.tgz",
+      "integrity": "sha512-64Eb6JLRRcER2NuIIVQIVNb3yn4mJLUwN1i3icmmNpTS+r4izwdM3eQs9wbeRjjX46kgfMZqPFYsC9JuGM0TKw=="
     },
     "node_modules/@otplib/preset-default": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@marsidev/react-turnstile": "^1.1.0",
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
+    "@otplib/preset-browser": "^12.0.1",
     "@otplib/preset-default": "^12.0.1",
     "@types/bcryptjs": "^3.0.0",
     "@types/nodemailer": "^6.4.17",


### PR DESCRIPTION
…ility

Install browser-compatible OTP library to resolve build errors in Workers environment.

🤖 Generated with [Claude Code](https://claude.ai/code)