### PR TITLE
Fix Cloudflare Workers TOTP build by using nodejs_compat with updated…

### DIFF
--- a/workers/auth/totp.ts
+++ b/workers/auth/totp.ts
@@ -1,4 +1,4 @@
-import { authenticator } from '@otplib/preset-browser';
+import { authenticator } from '@otplib/preset-default';
 import { hash, compare } from 'bcryptjs';
 import { v4 as uuidv4 } from 'uuid';
 import * as QRCode from 'qrcode';

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,7 +2,7 @@
 # Use: npm run dev (frontend) + npx wrangler dev (worker)
 name = "librarycard-api-local"
 main = "workers/index.ts"
-compatibility_date = "2024-09-23"
+compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "4bef1453ad78da6e3bb7e83b421e26df"
 


### PR DESCRIPTION
… compatibility date

Reverted from @otplib/preset-browser (which requires window object) back to @otplib/preset-default with updated compatibility_date to 2024-12-01 to enable nodejs_compat_v2 features with enhanced Node.js crypto module support.

🤖 Generated with [Claude Code](https://claude.ai/code)