### PR TITLE
Add esbuild configuration to externalize crypto module for Cloudflare…

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,18 @@
+// esbuild configuration for Wrangler
+module.exports = {
+  plugins: [
+    {
+      name: 'crypto-external',
+      setup(build) {
+        build.onResolve({ filter: /^crypto$/ }, () => ({
+          path: 'crypto',
+          external: true,
+        }));
+        build.onResolve({ filter: /^node:crypto$/ }, () => ({
+          path: 'node:crypto',
+          external: true,
+        }));
+      },
+    },
+  ],
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,10 @@ compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 account_id = "4bef1453ad78da6e3bb7e83b421e26df"
 
+[build]
+command = ""
+cwd = ""
+
 [vars]
 ENVIRONMENT = "local"
 APP_URL = "http://localhost:3000"


### PR DESCRIPTION
… Workers

Created esbuild plugin to treat crypto and node:crypto as external modules, resolving build errors where esbuild couldn't resolve the built-in crypto module. The nodejs_compat flag provides crypto at runtime.

🤖 Generated with [Claude Code](https://claude.ai/code)