### PR TITLE
Add nodejs_compat flag to staging-new wrangler config

### DIFF
--- a/wrangler.staging-new.toml
+++ b/wrangler.staging-new.toml
@@ -13,10 +13,15 @@
 
 name = "librarycard-api-staging"
 main = "workers/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
 
 # NEW ISOLATED ACCOUNT ID
 account_id = "18394f148930f0f3933fee06ecef99d0"
+
+[build]
+command = ""
+cwd = ""
 
 [vars]
 ENVIRONMENT = "staging"


### PR DESCRIPTION
The staging deployment was failing because wrangler.staging-new.toml was missing the nodejs_compat compatibility flag needed for crypto module support. Updated compatibility date to 2024-12-01 for latest features.

🤖 Generated with [Claude Code](https://claude.ai/code)