### PR TITLE
Remove rate limiting from 2FA setup to prevent user lockouts

### DIFF
--- a/workers/auth/rate-limiter.ts
+++ b/workers/auth/rate-limiter.ts
@@ -17,7 +17,7 @@ const RATE_LIMITS: Record<string, RateLimitConfig> = {
   'auth-forgot-password': { windowMs: 60 * 60 * 1000, maxAttempts: 3 }, // 3 attempts per hour
   'auth-reset-password': { windowMs: 60 * 60 * 1000, maxAttempts: 5 }, // 5 attempts per hour
   'auth-2fa-verify': { windowMs: 15 * 60 * 1000, maxAttempts: 10 }, // 10 attempts per 15 minutes for TOTP
-  'auth-2fa-setup': { windowMs: 60 * 60 * 1000, maxAttempts: 5 }, // 5 setup attempts per hour
+  // Removed rate limiting for 2FA setup since users must be authenticated
   'auth-2fa-disable': { windowMs: 60 * 60 * 1000, maxAttempts: 3 }, // 3 disable attempts per hour
   'api-general': { windowMs: 60 * 1000, maxAttempts: 100 }, // 100 requests per minute for general API
 };

--- a/workers/index.ts
+++ b/workers/index.ts
@@ -362,16 +362,7 @@ export default {
       }
 
       if (path === '/api/auth/2fa/setup' && request.method === 'POST') {
-        // Rate limit 2FA setup attempts
-        const rateLimitResult = await rateLimiter.checkRateLimit(clientId, 'auth-2fa-setup');
-        if (!rateLimitResult.allowed) {
-          const response = rateLimiter.createRateLimitResponse(rateLimitResult.resetTime!);
-          Object.entries(corsHeaders).forEach(([key, value]) => {
-            response.headers.set(key, value);
-          });
-          return response;
-        }
-        
+        // No rate limiting for 2FA setup since user is already authenticated
         return await twoFactorAuth.completeSetup(request, userId, corsHeaders);
       }
 


### PR DESCRIPTION
2FA setup now relies solely on authentication for security:
- Remove rate limiting from authenticated 2FA setup endpoint
- Authentication requirement provides sufficient protection
- Prevents legitimate users from being locked out during setup
- Maintains rate limiting for 2FA verification during login

🤖 Generated with [Claude Code](https://claude.ai/code)