### PR TITLE
Fix crypto module compatibility for production deployment

### DIFF
--- a/wrangler.prod.toml
+++ b/wrangler.prod.toml
@@ -14,7 +14,8 @@
 
 name = "librarycard-api-production"
 main = "workers/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
 
 # PRODUCTION ACCOUNT ID - SEPARATE FROM DEVELOPMENT
 # This should be a different Cloudflare account for maximum isolation

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -65,6 +65,7 @@ id = "22522f1582fc4b45b8b59446fca5c791"
 # Use: npx wrangler deploy --env=production
 [env.production]
 name = "librarycard-api-production"
+compatibility_flags = ["nodejs_compat"]
 
 [env.production.vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
Add nodejs_compat flag and update compatibility_date to 2024-12-01 in production environment configurations to resolve 'Could not resolve crypto' build errors during GitHub Actions deployment.

Changes:
- Add compatibility_flags = ['nodejs_compat'] to wrangler.prod.toml
- Add compatibility_flags = ['nodejs_compat'] to production env in wrangler.toml
- Update compatibility_date from 2024-01-01 to 2024-12-01 in wrangler.prod.toml

This mirrors the working staging-new configuration and enables the Web Crypto API-based 2FA system to deploy successfully to production.

🤖 Generated with [Claude Code](https://claude.ai/code)