### PR TITLE
Fix GitHub Actions deployment workflows with branch validation and de…

### DIFF
--- a/.github/workflows/deploy-production-enhanced.yml
+++ b/.github/workflows/deploy-production-enhanced.yml
@@ -42,6 +42,16 @@ jobs:
       deployment-approved: ${{ steps.confirmation.outputs.approved }}
     
     steps:
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "❌ This workflow can only be run from the 'main' branch"
+            echo "Current branch: ${{ github.ref_name }}"
+            echo "Required branch: main"
+            exit 1
+          fi
+          echo "✅ Branch validation passed: ${{ github.ref_name }}"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -181,7 +191,7 @@ jobs:
     name: Deploy Worker to Production
     runs-on: ubuntu-latest
     needs: [safety-validation, pre-deployment-backup]
-    if: always() && needs.safety-validation.result == 'success' && (needs.pre-deployment-backup.result == 'success' || needs.pre-deployment-backup.result == 'skipped')
+    if: always() && needs.safety-validation.result == 'success' && (needs.pre-deployment-backup.result == 'success' || needs.pre-deployment-backup.result == 'skipped') && (github.event.inputs.deployment_type == 'worker-only' || github.event.inputs.deployment_type == 'full-deployment')
     environment: production
     
     steps:
@@ -228,7 +238,7 @@ jobs:
     name: Deploy Database Migration
     runs-on: ubuntu-latest
     needs: [safety-validation, pre-deployment-backup, deploy-worker]
-    if: always() && needs.safety-validation.result == 'success' && needs.deploy-worker.result == 'success' && (github.event.inputs.deployment_type == 'database-migration' || github.event.inputs.deployment_type == 'full-deployment')
+    if: always() && needs.safety-validation.result == 'success' && (needs.pre-deployment-backup.result == 'success') && (needs.deploy-worker.result == 'success' || needs.deploy-worker.result == 'skipped') && (github.event.inputs.deployment_type == 'database-migration' || github.event.inputs.deployment_type == 'full-deployment')
     environment: production
     
     steps:
@@ -271,7 +281,7 @@ jobs:
     name: Post-Deployment Verification
     runs-on: ubuntu-latest
     needs: [deploy-worker, deploy-database]
-    if: always() && (needs.deploy-worker.result == 'success') && (needs.deploy-database.result == 'success' || needs.deploy-database.result == 'skipped')
+    if: always() && (needs.deploy-worker.result == 'success' || needs.deploy-worker.result == 'skipped') && (needs.deploy-database.result == 'success' || needs.deploy-database.result == 'skipped') && (needs.deploy-worker.result == 'success' || needs.deploy-database.result == 'success')
     environment: production
     
     steps:

--- a/.github/workflows/deploy-staging-enhanced.yml
+++ b/.github/workflows/deploy-staging-enhanced.yml
@@ -16,6 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Validate branch
+        run: |
+          if [ "${{ github.ref_name }}" != "staging" ]; then
+            echo "❌ This workflow can only be run from the 'staging' branch"
+            echo "Current branch: ${{ github.ref_name }}"
+            echo "Required branch: staging"
+            exit 1
+          fi
+          echo "✅ Branch validation passed: ${{ github.ref_name }}"
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
…ployment type logic

Security and Logic Fixes:
- Add branch validation to prevent wrong-branch deployments (production: main only, staging: staging only)
- Fix deployment type redundancy where 'database-migration' and 'full-deployment' were identical
- Implement proper conditional logic for distinct deployment types

Changes:
- Production workflow: Add main branch validation, fix deployment type conditions
- Staging workflow: Add staging branch validation
- deploy-worker job: Only runs for 'worker-only' and 'full-deployment' types
- deploy-database job: Handles skipped worker deployments properly
- post-deployment-verification: Runs when at least one deployment succeeds

Deployment Types Now Work Correctly:
- worker-only: Worker code only (no database changes, no backup)
- database-migration: Database migration only (with backup, no worker deployment)
- full-deployment: Both worker code and database migration (with backup)

Resolves GitHub Issue #191

🤖 Generated with [Claude Code](https://claude.ai/code)