### PR TITLE
HOTFIX: Fix production APP_URL trailing slash causing CORS errors

### DIFF
--- a/wrangler.prod.toml
+++ b/wrangler.prod.toml
@@ -23,7 +23,7 @@ account_id = "4bef1453ad78da6e3bb7e83b421e26df"  # TODO: Replace with separate p
 
 [vars]
 ENVIRONMENT = "production"
-APP_URL = "https://librarycard.tim52.io/"
+APP_URL = "https://librarycard.tim52.io"
 FROM_EMAIL = "LibraryCard <librarian@tim52.io>"
 
 # Production Database - LIVE DATA
@@ -43,7 +43,7 @@ name = "librarycard-api-production"
 
 [env.production.vars]
 ENVIRONMENT = "production"
-APP_URL = "https://librarycard.tim52.io/"
+APP_URL = "https://librarycard.tim52.io"
 FROM_EMAIL = "LibraryCard <librarian@tim52.io>"
 
 [[env.production.d1_databases]]


### PR DESCRIPTION
Remove trailing slash from APP_URL in production configuration. The trailing slash was causing CORS origin mismatches between frontend (https://librarycard.tim52.io) and backend (https://librarycard.tim52.io/).

Symptoms:
- Users can log in but see no books/locations/admin tabs
- CORS errors visible in browser network tab
- Staging works fine (no trailing slash)

🤖 Generated with [Claude Code](https://claude.ai/code)