### PR TITLE
Configure Next.js webpack cache for GitHub Actions builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,20 @@ const nextConfig = {
   images: {
     domains: ['books.google.com', 'covers.openlibrary.org'],
   },
+  // Configure build caching
+  distDir: '.next',
   // Optimize for Cloudflare Pages deployment
   webpack: (config) => {
-    // Disable filesystem cache for Cloudflare Pages to avoid large files
-    if (process.env.CF_PAGES) {
+    // Enable filesystem cache for GitHub Actions builds
+    if (process.env.GITHUB_ACTIONS) {
+      const path = require('path');
+      config.cache = {
+        type: 'filesystem',
+        cacheDirectory: path.resolve('.next/cache/webpack'),
+        maxMemoryGenerations: 2,
+      };
+    } else if (process.env.CF_PAGES) {
+      // Disable filesystem cache for Cloudflare Pages to avoid large files
       config.cache = false;
     } else if (config.cache && config.cache.type === 'filesystem') {
       // Reduce webpack cache size for other deployments


### PR DESCRIPTION
- Add GITHUB_ACTIONS environment detection in next.config.js
- Enable filesystem webpack cache with absolute path resolution
- Configure cache directory at .next/cache/webpack for GitHub Actions
- Eliminates 'No build cache found' warning in GitHub Actions workflows