### PR TITLE
Fix TypeScript lint errors causing build failure

### DIFF
--- a/src/components/book/BookGrid.tsx
+++ b/src/components/book/BookGrid.tsx
@@ -346,6 +346,9 @@ const BookCard = React.memo<BookCardProps>(({
   )
 })
 
+// Add display name for debugging
+BookCard.displayName = 'BookCard'
+
 // Optimized BookGrid component with React.memo
 const BookGrid = React.memo<BookGridProps>(({
   books,
@@ -409,5 +412,8 @@ const BookGrid = React.memo<BookGridProps>(({
     </Box>
   )
 })
+
+// Add display name for debugging
+BookGrid.displayName = 'BookGrid'
 
 export default BookGrid

--- a/src/lib/bookApi.ts
+++ b/src/lib/bookApi.ts
@@ -710,7 +710,7 @@ function mergeSubjects(google: any, openLibrary: any, loc: LocBookData | null): 
   return Array.from(new Set(subjects))
 }
 
-function aggregateAllCovers(google: any, openLibrary: any, loc: LocBookData | null): EnhancedCoverOption[] {
+function aggregateAllCovers(google: GoogleBookData | null, openLibrary: OpenLibraryBookData | null, loc: LocBookData | null): EnhancedCoverOption[] {
   const covers: EnhancedCoverOption[] = []
   
   // Google Books covers
@@ -719,7 +719,7 @@ function aggregateAllCovers(google: any, openLibrary: any, loc: LocBookData | nu
       covers.push({
         source: 'google',
         url: url as string,
-        size: size as any,
+        size: size as string,
         metadata: {
           quality: size === 'extraLarge' ? 'high' : size === 'large' ? 'medium' : 'low'
         }
@@ -760,7 +760,7 @@ function aggregateAllCovers(google: any, openLibrary: any, loc: LocBookData | nu
   return covers
 }
 
-function getCoverSources(google: any, openLibrary: any, loc: LocBookData | null): DataSource[] {
+function getCoverSources(google: GoogleBookData | null, openLibrary: OpenLibraryBookData | null, loc: LocBookData | null): DataSource[] {
   const sources: DataSource[] = []
   
   if (google?.imageLinks && Object.keys(google.imageLinks).length > 0) {


### PR DESCRIPTION
- Fix any types in bookApi.ts aggregateAllCovers and getCoverSources functions
- Add display names to React.memo components (BookCard, BookGrid)
- Use proper types (GoogleBookData, OpenLibraryBookData) instead of any
- Resolve critical ESLint errors that were blocking staging deployment

🤖 Generated with [Claude Code](https://claude.ai/code)