### PR TITLE
Fix TypeScript interface definitions causing build failures

### DIFF
--- a/src/lib/bookApi.ts
+++ b/src/lib/bookApi.ts
@@ -250,12 +250,27 @@ export async function fetchEnhancedBookFromSearch(googleBookItem: GoogleBookItem
 
 // Type definitions for API responses
 interface GoogleBookData {
+  title?: string
+  authors?: string[]
+  description?: string
+  categories?: string[]
+  publisher?: string
+  publishedDate?: string
+  pageCount?: number
+  averageRating?: number
+  ratingsCount?: number
   imageLinks?: {
     [size: string]: string
   }
 }
 
 interface OpenLibraryBookData {
+  title?: string
+  authors?: { name: string }[]
+  description?: string | { value: string }
+  subjects?: string[]
+  publishers?: string[]
+  publish_date?: string
   covers?: number[]
 }
 

--- a/src/lib/fieldSelection.ts
+++ b/src/lib/fieldSelection.ts
@@ -110,7 +110,7 @@ export function selectBookFields<T extends FieldSet>(
     }
   }
   
-  return selectedBook
+  return selectedBook as T extends 'grid' ? GridBook : T extends 'detail' ? DetailBook : T extends 'search' ? SearchBook : FullBook
 }
 
 // Filter array of books


### PR DESCRIPTION
- Complete GoogleBookData interface with missing properties (categories, publisher, etc.)
- Complete OpenLibraryBookData interface with subjects, publishers, and other fields
- Fix type assertion in fieldSelection.ts selectBookFields function
- Build now compiles successfully without TypeScript errors

All TypeScript compilation errors resolved. Staging deployment ready to proceed.

🤖 Generated with [Claude Code](https://claude.ai/code)