### PR TITLE
Improve genre selection UX with instant addition and visual feedback

### DIFF
--- a/src/components/book/BookCompact.tsx
+++ b/src/components/book/BookCompact.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   Chip,
   Button,
+  Grow,
 } from '@mui/material'
 import { Info, Star, Edit, MenuBook } from '@mui/icons-material'
 import type { EnhancedBook } from '@/lib/types'
@@ -249,22 +250,36 @@ export default function BookList({
                   {(() => {
                     const { genres, source } = getDisplayGenres(book)
                     return genres.length > 0 && (
-                      <Chip 
-                        label={genres[0]} 
-                        size="small" 
-                        color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
-                        onClick={undefined}
-                        sx={{ 
-                          fontSize: { xs: '0.7rem', sm: '0.75rem', md: '0.8125rem' },
-                          height: { xs: 20, sm: 24, md: 28 },
-                          maxWidth: '120px',
-                          '& .MuiChip-label': {
-                            textOverflow: 'ellipsis',
-                            overflow: 'hidden',
-                            whiteSpace: 'nowrap'
-                          }
-                        }} 
-                      />
+                      <Grow in={true} timeout={source === 'assigned' ? 800 : 0}>
+                        <Chip 
+                          label={genres[0]} 
+                          size="small" 
+                          color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
+                          onClick={undefined}
+                          sx={{ 
+                            fontSize: { xs: '0.7rem', sm: '0.75rem', md: '0.8125rem' },
+                            height: { xs: 20, sm: 24, md: 28 },
+                            maxWidth: '120px',
+                            animation: source === 'assigned' ? 'pulse 2s ease-in-out' : undefined,
+                            '@keyframes pulse': {
+                              '0%': {
+                                boxShadow: '0 0 0 0 rgba(156, 39, 176, 0.4)'
+                              },
+                              '70%': {
+                                boxShadow: '0 0 0 10px rgba(156, 39, 176, 0)'
+                              },
+                              '100%': {
+                                boxShadow: '0 0 0 0 rgba(156, 39, 176, 0)'
+                              }
+                            },
+                            '& .MuiChip-label': {
+                              textOverflow: 'ellipsis',
+                              overflow: 'hidden',
+                              whiteSpace: 'nowrap'
+                            }
+                          }} 
+                        />
+                      </Grow>
                     )
                   })()}
                   

--- a/src/components/book/BookGrid.tsx
+++ b/src/components/book/BookGrid.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Chip,
   Button,
+  Grow,
 } from '@mui/material'
 import { Info, Star, Edit, Image, MenuBook } from '@mui/icons-material'
 import type { EnhancedBook } from '@/lib/types'
@@ -243,22 +244,36 @@ const BookCard = React.memo<BookCardProps>(({
               {(() => {
                 const { genres, source } = getDisplayGenres(book)
                 return genres.length > 0 && (
-                  <Chip 
-                    label={genres[0]} 
-                    size="small" 
-                    color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
-                    onClick={undefined}
-                    sx={{ 
-                      fontSize: '0.7rem', 
-                      height: 20,
-                      maxWidth: '120px',
-                      '& .MuiChip-label': {
-                        textOverflow: 'ellipsis',
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap'
-                      }
-                    }} 
-                  />
+                  <Grow in={true} timeout={source === 'assigned' ? 800 : 0}>
+                    <Chip 
+                      label={genres[0]} 
+                      size="small" 
+                      color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
+                      onClick={undefined}
+                      sx={{ 
+                        fontSize: '0.7rem', 
+                        height: 20,
+                        maxWidth: '120px',
+                        animation: source === 'assigned' ? 'pulse 2s ease-in-out' : undefined,
+                        '@keyframes pulse': {
+                          '0%': {
+                            boxShadow: '0 0 0 0 rgba(156, 39, 176, 0.4)'
+                          },
+                          '70%': {
+                            boxShadow: '0 0 0 10px rgba(156, 39, 176, 0)'
+                          },
+                          '100%': {
+                            boxShadow: '0 0 0 0 rgba(156, 39, 176, 0)'
+                          }
+                        },
+                        '& .MuiChip-label': {
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap'
+                        }
+                      }} 
+                    />
+                  </Grow>
                 )
               })()}
             </Box>

--- a/src/components/book/BookList.tsx
+++ b/src/components/book/BookList.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   Chip,
   IconButton,
+  Grow,
 } from '@mui/material'
 import { Info, Star, Edit } from '@mui/icons-material'
 import type { EnhancedBook } from '@/lib/types'
@@ -175,22 +176,36 @@ export default function BookText({
               {(() => {
                 const { genres, source } = getDisplayGenres(book)
                 return genres.length > 0 && (
-                  <Chip 
-                    label={genres[0]} 
-                    size="small" 
-                    color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
-                    onClick={undefined}
-                    sx={{ 
-                      fontSize: '0.7rem', 
-                      height: 20,
-                      maxWidth: '120px',
-                      '& .MuiChip-label': {
-                        textOverflow: 'ellipsis',
-                        overflow: 'hidden',
-                        whiteSpace: 'nowrap'
-                      }
-                    }}
-                  />
+                  <Grow in={true} timeout={source === 'assigned' ? 800 : 0}>
+                    <Chip 
+                      label={genres[0]} 
+                      size="small" 
+                      color={source === 'assigned' ? 'secondary' : source === 'enhanced' ? 'primary' : 'default'}
+                      onClick={undefined}
+                      sx={{ 
+                        fontSize: '0.7rem', 
+                        height: 20,
+                        maxWidth: '120px',
+                        animation: source === 'assigned' ? 'pulse 2s ease-in-out' : undefined,
+                        '@keyframes pulse': {
+                          '0%': {
+                            boxShadow: '0 0 0 0 rgba(156, 39, 176, 0.4)'
+                          },
+                          '70%': {
+                            boxShadow: '0 0 0 10px rgba(156, 39, 176, 0)'
+                          },
+                          '100%': {
+                            boxShadow: '0 0 0 0 rgba(156, 39, 176, 0)'
+                          }
+                        },
+                        '& .MuiChip-label': {
+                          textOverflow: 'ellipsis',
+                          overflow: 'hidden',
+                          whiteSpace: 'nowrap'
+                        }
+                      }}
+                    />
+                  </Grow>
                 )
               })()}
               

--- a/src/components/book/GenreSelector.tsx
+++ b/src/components/book/GenreSelector.tsx
@@ -14,7 +14,6 @@ import {
   FormControl,
 } from '@mui/material'
 import {
-  Add,
   Check,
   Close,
 } from '@mui/icons-material'
@@ -38,6 +37,7 @@ export default function GenreSelector({
   const [suggestedGenres, setSuggestedGenres] = useState<CuratedGenre[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [autocompleteValue, setAutocompleteValue] = useState<CuratedGenre | null>(null)
+  const [inputValue, setInputValue] = useState('')
 
   // Load available genres from database
   useEffect(() => {
@@ -95,10 +95,13 @@ export default function GenreSelector({
     setSuggestedGenres(prev => prev.filter(g => g.id !== genre.id))
   }
 
-  const handleAddFromAutocomplete = () => {
-    if (autocompleteValue && !selectedGenres.find(g => g.id === autocompleteValue.id)) {
-      onGenresChange([...selectedGenres, autocompleteValue])
+  const handleAutocompleteChange = (newValue: CuratedGenre | null) => {
+    if (newValue && !selectedGenres.find(g => g.id === newValue.id)) {
+      onGenresChange([...selectedGenres, newValue])
       setAutocompleteValue(null)
+      setInputValue('')
+    } else {
+      setAutocompleteValue(newValue)
     }
   }
 
@@ -189,56 +192,40 @@ export default function GenreSelector({
 
       {/* Add Custom Genre */}
       <Box sx={{ pb: 2 }}>
-        <Box sx={{ display: 'flex', gap: 1, alignItems: 'stretch' }}>
-          <FormControl fullWidth size="small">
-            <Autocomplete
-              value={autocompleteValue}
-              onChange={(_, newValue) => setAutocompleteValue(newValue)}
-              options={availableForAutocomplete}
-              getOptionLabel={(option) => option.name}
-              renderOption={(props, option) => (
-                <li {...props}>
-                  <Box>
-                    <Typography variant="body2">{option.name}</Typography>
-                    {option.description && (
-                      <Typography variant="caption" color="text.secondary">
-                        {option.description}
-                      </Typography>
-                    )}
-                  </Box>
-                </li>
-              )}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Add Genres"
-                  variant="outlined"
-                  size="small"
-                  placeholder="Type to search..."
-                />
-              )}
-              sx={{ flexGrow: 1, minWidth: 200 }}
-              ListboxProps={{
-                style: { maxHeight: 200 }
-              }}
-            />
-          </FormControl>
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<Add />}
-            onClick={handleAddFromAutocomplete}
-            disabled={!autocompleteValue}
-            sx={{ 
-              whiteSpace: 'nowrap',
-              height: '40px', // Match the height of small TextField
-              minWidth: { xs: '120px', sm: 'auto' }, // Ensure minimum width on mobile
-              px: { xs: 2, sm: 1.5 } // More padding on mobile for better text fit
+        <FormControl fullWidth size="small">
+          <Autocomplete
+            value={autocompleteValue}
+            onChange={(_, newValue) => handleAutocompleteChange(newValue)}
+            inputValue={inputValue}
+            onInputChange={(_, newInputValue) => setInputValue(newInputValue)}
+            options={availableForAutocomplete}
+            getOptionLabel={(option) => option.name}
+            renderOption={(props, option) => (
+              <li {...props}>
+                <Box>
+                  <Typography variant="body2">{option.name}</Typography>
+                  {option.description && (
+                    <Typography variant="caption" color="text.secondary">
+                      {option.description}
+                    </Typography>
+                  )}
+                </Box>
+              </li>
+            )}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Add Genres"
+                variant="outlined"
+                size="small"
+                placeholder="Select genre to add instantly..."
+              />
+            )}
+            ListboxProps={{
+              style: { maxHeight: 200 }
             }}
-          >
-            Add Genre
-          </Button>
-        </Box>
+          />
+        </FormControl>
       </Box>
 
     </Box>

--- a/src/components/library/BookLibrary.tsx
+++ b/src/components/library/BookLibrary.tsx
@@ -140,7 +140,6 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
   const [selectedBookForRating, setSelectedBookForRating] = useState<EnhancedBook | null>(null)
   const [selectedBookForGenreEdit, setSelectedBookForGenreEdit] = useState<EnhancedBook | null>(null)
   const [selectedBookForCoverEdit, setSelectedBookForCoverEdit] = useState<EnhancedBook | null>(null)
-  const [genreUpdateSuccessful, setGenreUpdateSuccessful] = useState(false)
 
   // Modal handlers
   const handleMoreDetailsClick = (book: EnhancedBook) => {
@@ -212,19 +211,6 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
   // Genre edit handlers
   const handleGenreEditModalClose = () => {
     setSelectedBookForGenreEdit(null)
-    if (genreUpdateSuccessful) {
-      alert({
-        title: 'Genres Updated',
-        message: 'Book genres have been updated successfully.',
-        variant: 'success'
-      })
-      setGenreUpdateSuccessful(false)
-    }
-  }
-
-  const handleGenreUpdateWrapper = async (bookId: string, genres: any[]) => {
-    await handleGenreUpdate(bookId, genres)
-    setGenreUpdateSuccessful(true)
   }
 
   // Cover edit handlers
@@ -541,7 +527,7 @@ export default function BookLibrary({ initialFilters }: BookLibraryProps = {}) {
             book={selectedBookForGenreEdit}
             isOpen={true}
             onClose={handleGenreEditModalClose}
-            onGenreUpdate={handleGenreUpdateWrapper}
+            onGenreUpdate={handleGenreUpdate}
           />
         )}
 


### PR DESCRIPTION
- Remove "Add Genre" button for streamlined one-click genre selection
- Enable instant genre addition when selected from dropdown
- Clear dropdown input automatically after selection for better multi-selection flow
- Remove confirmation alert after saving genres to reduce click friction
- Add subtle pulse animation to newly assigned genres across all book views
- Maintain consistent animation behavior in Grid, List, and Compact view modes

🤖 Generated with [Claude Code](https://claude.ai/code)