### PR TITLE
Fix Node.js version in production schema check workflow

### DIFF
--- a/.github/workflows/check-production-schema.yml
+++ b/.github/workflows/check-production-schema.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
- Update from Node.js 18 to Node.js 20 to meet Wrangler requirements
- Wrangler requires at least Node.js v20.0.0

🤖 Generated with [Claude Code](https://claude.ai/code)