### PR TITLE
Add simple migration to fix book_genres schema for staging

### DIFF
--- a/migrations/fix_book_genres_simple.sql
+++ b/migrations/fix_book_genres_simple.sql
@@ -1,0 +1,63 @@
+-- Simple fix for book_genres table schema
+-- Drop existing table and recreate with proper schema
+-- Note: This will lose existing book-genre assignments
+
+-- Create curated_genres table if it doesn't exist
+CREATE TABLE IF NOT EXISTS curated_genres (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  created_by TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  is_active BOOLEAN DEFAULT TRUE,
+  FOREIGN KEY (created_by) REFERENCES users(id)
+);
+
+-- Drop and recreate book_genres with correct schema
+DROP TABLE IF EXISTS book_genres;
+
+CREATE TABLE book_genres (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  book_id INTEGER NOT NULL,
+  genre_id INTEGER NOT NULL,
+  assigned_by TEXT NOT NULL,
+  assigned_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  is_auto_assigned BOOLEAN DEFAULT FALSE,
+  FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE,
+  FOREIGN KEY (genre_id) REFERENCES curated_genres(id) ON DELETE CASCADE,
+  FOREIGN KEY (assigned_by) REFERENCES users(id),
+  UNIQUE(book_id, genre_id)
+);
+
+-- Create genre_suggestions table if it doesn't exist
+CREATE TABLE IF NOT EXISTS genre_suggestions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  suggested_name TEXT NOT NULL,
+  description TEXT,
+  suggested_by TEXT NOT NULL,
+  book_id INTEGER,
+  status TEXT DEFAULT 'pending',
+  reviewed_by TEXT,
+  reviewed_at DATETIME,
+  review_comment TEXT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (suggested_by) REFERENCES users(id),
+  FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE SET NULL,
+  FOREIGN KEY (reviewed_by) REFERENCES users(id)
+);
+
+-- Create all indexes
+CREATE INDEX IF NOT EXISTS idx_curated_genres_name ON curated_genres(name);
+CREATE INDEX IF NOT EXISTS idx_curated_genres_active ON curated_genres(is_active);
+CREATE INDEX IF NOT EXISTS idx_curated_genres_created_by ON curated_genres(created_by);
+
+CREATE INDEX IF NOT EXISTS idx_book_genres_book ON book_genres(book_id);
+CREATE INDEX IF NOT EXISTS idx_book_genres_genre ON book_genres(genre_id);
+CREATE INDEX IF NOT EXISTS idx_book_genres_assigned_by ON book_genres(assigned_by);
+CREATE INDEX IF NOT EXISTS idx_book_genres_auto_assigned ON book_genres(is_auto_assigned);
+
+CREATE INDEX IF NOT EXISTS idx_genre_suggestions_status ON genre_suggestions(status);
+CREATE INDEX IF NOT EXISTS idx_genre_suggestions_suggested_by ON genre_suggestions(suggested_by);
+CREATE INDEX IF NOT EXISTS idx_genre_suggestions_book ON genre_suggestions(book_id);
+CREATE INDEX IF NOT EXISTS idx_genre_suggestions_reviewed_by ON genre_suggestions(reviewed_by);


### PR DESCRIPTION
- Drops existing book_genres table and recreates with proper schema
- Avoids complex data preservation that fails due to unknown existing schema
- Simple approach for staging environment where data loss is acceptable
- Creates all required genre management tables and indexes
- After this migration, staging schema will match production schema

🤖 Generated with [Claude Code](https://claude.ai/code)