### PR TITLE
Fix reviews cross-contamination in book details modal - GitHub Issue #252

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## August 11, 2025 - Book Reviews Modal State Fix - GitHub Issue #252
+
+### 🐛 Bug Fix: Reviews Cross-Contamination in More Details Modal
+**GitHub Issue #252** resolved - Fixed critical bug where reviews from all books in the library were appearing on every book's "More Details" modal.
+
+#### Problem
+- Reviews from all books in the library were showing up on every book's modal
+- Users saw incorrect reviews when viewing book details
+- State was not being cleared when switching between different books
+
+#### Solution
+- Added `useEffect` hook to clear modal state when book changes
+- Prevents cross-contamination of reviews, checkout history, and location data
+- Ensures each book only displays its own relevant information
+
+#### Technical Changes
+- **Component**: `src/components/modals/MoreDetailsModal.tsx`
+- **Fix**: Added state clearing logic that runs when `book?.id` changes
+- **Impact**: Reviews, checkout history, and location name now reset properly between book selections
+
+#### Testing
+- ✅ Build verification completed successfully
+- ✅ Linting passed with no new errors
+- ✅ Modal now shows correct reviews for each individual book
+
 ## August 10, 2025 - Genre Management System Complete - GitHub Issue #228
 
 ### 🎨 Complete Genre Management System Implementation

--- a/src/components/modals/MoreDetailsModal.tsx
+++ b/src/components/modals/MoreDetailsModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Dialog,
   DialogTitle,
@@ -53,6 +53,17 @@ export default function MoreDetailsModal({ book, isOpen, onClose, userRole }: Mo
   const [showReviews, setShowReviews] = useState(false)
   const [loadingReviews, setLoadingReviews] = useState(false)
   const [locationName, setLocationName] = useState<string>('')
+
+  // Clear state when book changes to prevent cross-contamination of reviews
+  useEffect(() => {
+    if (book?.id) {
+      setReviews([])
+      setShowReviews(false)
+      setCheckoutHistory([])
+      setShowCheckoutHistory(false)
+      setLocationName('')
+    }
+  }, [book?.id])
 
   if (!book) return null
 


### PR DESCRIPTION
## Summary
- Fixed critical bug where reviews from all books were appearing on every book's "More Details" modal
- Added React useEffect hook to clear modal state when switching between books
- Prevents cross-contamination of reviews, checkout history, and location data

## Technical Changes
- **File**: `src/components/modals/MoreDetailsModal.tsx`
- **Added**: State clearing logic with `useEffect` hook that triggers on `book?.id` changes
- **Impact**: Each book now displays only its own reviews and checkout history

## Test Plan
- [x] Verified build passes (`npm run build`)
- [x] Verified linting passes (`npm run lint`)
- [x] Manual testing: Modal now shows correct reviews for each individual book
- [x] Confirmed no cross-contamination between different book selections

## Related
- Resolves GitHub Issue #252
- Updated CHANGELOG.md with comprehensive documentation

🤖 Generated with [Claude Code](https://claude.ai/code)