### PR TITLE
Fix API_BASE_URL export to function instead of function call

### DIFF
--- a/src/lib/apiConfig.ts
+++ b/src/lib/apiConfig.ts
@@ -15,5 +15,5 @@ export const getApiBaseUrl = (): string => {
   return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787'
 }
 
-// Export the result of calling the function
-export const API_BASE_URL = getApiBaseUrl()
+// Export the function directly to avoid computing during build
+export const API_BASE_URL = getApiBaseUrl


### PR DESCRIPTION
This ensures that API routes can call API_BASE_URL() as a function. The previous merge accidentally had the function being called instead of exported.

Fixes build error: 'This expression is not callable. Type 'String' has no call signatures.'