### PR TITLE
Fix wrangler configuration for staging-new environment

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -37,7 +37,8 @@ class MigrationRunner {
       'staging-new': {
         database: 'librarycard-db-staging-new',
         remote: true,
-        env: 'staging-new'
+        config: 'wrangler.staging-new.toml',
+        env: 'staging'
       },
       production: {
         database: 'librarycard-db-production',
@@ -86,6 +87,10 @@ class MigrationRunner {
       
       if (this.dbConfig.remote) {
         args.push('--remote');
+      }
+      
+      if (this.dbConfig.config) {
+        args.push('--config', this.dbConfig.config);
       }
       
       if (this.dbConfig.env) {
@@ -144,6 +149,10 @@ class MigrationRunner {
       
       if (this.dbConfig.remote) {
         args.push('--remote');
+      }
+      
+      if (this.dbConfig.config) {
+        args.push('--config', this.dbConfig.config);
       }
       
       if (this.dbConfig.env) {


### PR DESCRIPTION
- Use wrangler.staging-new.toml config file instead of --env staging-new
- Change environment to 'staging' to match the config file structure
- Add --config parameter support to both executeSQL methods
- This resolves the 'No environment found in configuration' error

The staging deployment should now work correctly with the isolated account.