### PR TITLE
Improve error logging for wrangler command failures

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -124,9 +124,12 @@ class MigrationRunner {
             executionTime
           });
         } else {
+          const command = `wrangler ${args.join(' ')}`;
           this.log(`❌ ${description} failed with code ${code}`);
-          this.log(`Error: ${stderr}`);
-          reject(new Error(`${description} failed: ${stderr}`));
+          this.log(`❌ Command: ${command}`);
+          this.log(`❌ STDOUT: ${stdout}`);
+          this.log(`❌ STDERR: ${stderr}`);
+          reject(new Error(`${description} failed with code ${code}: ${stderr || stdout || 'No output'}`));
         }
       });
     });
@@ -186,9 +189,12 @@ class MigrationRunner {
             executionTime
           });
         } else {
+          const command = `wrangler ${args.join(' ')}`;
           this.log(`❌ ${description} failed with code ${code}`);
-          this.log(`Error: ${stderr}`);
-          reject(new Error(`${description} failed: ${stderr}`));
+          this.log(`❌ Command: ${command}`);
+          this.log(`❌ STDOUT: ${stdout}`);
+          this.log(`❌ STDERR: ${stderr}`);
+          reject(new Error(`${description} failed with code ${code}: ${stderr || stdout || 'No output'}`));
         }
       });
     });


### PR DESCRIPTION
Add detailed logging of:
- Full wrangler command being executed
- Exit codes
- Both STDOUT and STDERR output
- Fallback to 'No output' when both are empty

This will help debug the staging migration configuration issues.