### PR TITLE
Fix missing CLOUDFLARE_API_TOKEN in workflow migration status check

### DIFF
--- a/.github/workflows/automated-migrations.yml
+++ b/.github/workflows/automated-migrations.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Check migration status
         id: status
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ github.event.inputs.environment == 'staging' && secrets.CLOUDFLARE_API_TOKEN_STAGING_NEW || secrets.CLOUDFLARE_API_TOKEN_PRODUCTION }}
         run: |
           echo "🔍 Checking migration status for ${{ github.event.inputs.environment }}..."
           


### PR DESCRIPTION
- Add CLOUDFLARE_API_TOKEN environment variable to migration status step
- Allows bootstrap safety check to query database for existing tables
- Fixes 'wrangler requires API token in non-interactive environment' error