### PR TITLE
Fix bootstrap UNIQUE constraint error with INSERT OR IGNORE

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -304,7 +304,7 @@ class MigrationRunner {
    */
   async recordMigrationApplied(migration, batchId, executionTime) {
     const sql = `
-      INSERT INTO migrations_applied (filename, checksum, execution_time_ms, batch_id)
+      INSERT OR IGNORE INTO migrations_applied (filename, checksum, execution_time_ms, batch_id)
       VALUES ('${migration.filename}', '${migration.checksum}', ${executionTime}, '${batchId}')
     `;
     


### PR DESCRIPTION
- Use INSERT OR IGNORE for recording migrations as applied
- Handles partial bootstrap state where some migration records may already exist
- Allows smart bootstrap to be safely re-run if it fails partway through