### PR TITLE
Fix migration analysis to correctly categorize column-adding migrations

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -842,6 +842,14 @@ class MigrationRunner {
           if (tables.length > 0 && tables.every(table => existingTables.has(table))) {
             migrationCreatesExistingSchema = true;
           }
+          // Special handling for migrations that add columns to existing tables (empty array)
+          else if (tables.length === 0) {
+            // These migrations modify existing tables - assume they've been applied if core tables exist
+            const coreTablesExist = existingTables.has('users') && existingTables.has('books') && existingTables.has('locations');
+            if (coreTablesExist) {
+              migrationCreatesExistingSchema = true;
+            }
+          }
           break;
         }
       }


### PR DESCRIPTION
- Add special handling for migrations with empty table arrays (column additions)
- These migrations modify existing tables rather than creating new ones
- Assume they're applied if core tables (users, books, locations) exist
- Fixes add_auth_columns.sql being incorrectly categorized as new migration