### PR TITLE
Fix deprecated wrangler commands in backup workflows

### DIFF
--- a/.github/workflows/cloudflare-backup.yml
+++ b/.github/workflows/cloudflare-backup.yml
@@ -124,12 +124,9 @@ jobs:
           # Try to get worker info
           wrangler whoami > worker-auth-info.txt || echo "Auth info failed"
           
-          # List workers
-          wrangler list > workers-list.txt || echo "Workers list failed"
-          
-          # Get current deployment info if possible
+          # Get deployment info using modern wrangler commands
           echo "Checking worker deployment status..." > deployment-status.txt
-          wrangler status || echo "Status check failed" >> deployment-status.txt
+          wrangler deployments list --name=librarycard-worker >> deployment-status.txt || echo "Deployments check failed" >> deployment-status.txt
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       

--- a/.github/workflows/staging-cloudflare-backup.yml
+++ b/.github/workflows/staging-cloudflare-backup.yml
@@ -227,12 +227,9 @@ jobs:
           # Try to get worker info
           wrangler whoami > worker-auth-info.txt || echo "Auth info failed"
           
-          # List workers
-          wrangler list > workers-list.txt || echo "Workers list failed"
-          
-          # Get current deployment info if possible
+          # Get deployment info using modern wrangler commands
           echo "Checking staging worker deployment status..." > deployment-status.txt
-          wrangler status || echo "Status check failed" >> deployment-status.txt
+          wrangler deployments list --name=librarycard-worker-staging >> deployment-status.txt || echo "Deployments check failed" >> deployment-status.txt
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_STAGING_NEW }}
       


### PR DESCRIPTION
- Replace 'wrangler list' and 'wrangler status' with modern 'wrangler deployments list'
- These commands were causing errors but not affecting backup functionality
- Backup core functionality (30 tables, 289 rows) worked successfully