### PR TITLE
Fix production database name in migration and restore workflows

### DIFF
--- a/.github/workflows/production-cloudflare-restore.yml
+++ b/.github/workflows/production-cloudflare-restore.yml
@@ -174,12 +174,12 @@ jobs:
           
           if [ -f "database-schema-backup.sql" ]; then
             echo "📋 Applying schema backup..."
-            wrangler d1 execute librarycard-db-production --env=production --remote --file=database-schema-backup.sql
+            wrangler d1 execute librarycard-db --env=production --remote --file=database-schema-backup.sql
             echo "✅ Schema restored"
           else
             echo "⚠️  No schema backup found - attempting schema.sql"
             if [ -f "schema.sql" ]; then
-              wrangler d1 execute librarycard-db-production --env=production --remote --file=schema.sql
+              wrangler d1 execute librarycard-db --env=production --remote --file=schema.sql
               echo "✅ Base schema applied"
             else
               echo "❌ No schema files available"
@@ -233,7 +233,7 @@ jobs:
           echo "🔍 Verifying basic PRODUCTION database connectivity..."
           
           # Test basic database connectivity
-          wrangler d1 execute librarycard-db-production --env=production --remote --command="SELECT name FROM sqlite_master WHERE type='table';" || echo "Table list check failed"
+          wrangler d1 execute librarycard-db --env=production --remote --command="SELECT name FROM sqlite_master WHERE type='table';" || echo "Table list check failed"
           
           echo "✅ Basic connectivity verified"
         env:

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -41,7 +41,7 @@ class MigrationRunner {
         env: 'staging'
       },
       production: {
-        database: 'librarycard-db-production',
+        database: 'librarycard-db',
         remote: true,
         env: 'production'
       }


### PR DESCRIPTION
- Change 'librarycard-db-production' to 'librarycard-db'
- Matches actual production database name in Cloudflare
- Fixes migration script database configuration
- Fixes production restore workflow database references
- Resolves database name error in production dry-run migration