### PR TITLE
Add foreign key constraint handling to restore processes

### DIFF
--- a/.github/workflows/test-restore-workflow-staging.yml
+++ b/.github/workflows/test-restore-workflow-staging.yml
@@ -169,6 +169,10 @@ jobs:
           # Define table order (same as production restore would use)
           echo "📋 Preparing staging restore with production restore logic..."
           
+          # Disable foreign key constraints for restore
+          echo "🔧 Disabling foreign key constraints..."
+          npx wrangler d1 execute librarycard-db-staging-new --config=wrangler.staging-new.toml --env=staging --remote --command="PRAGMA foreign_keys = OFF;" || echo "Could not disable foreign key constraints"
+          
           # Use the production backup data but restore to staging
           BACKUP_FILE="../backups-production/prod-backup-*.json"
           
@@ -329,6 +333,15 @@ jobs:
             console.log(`   📊 Test rows processed: ${testRows}`);
             console.log(`   🎯 This validates the restore process logic`);
             console.log(`   ⚠️  Full restore would process all ${totalRows} rows`);
+            
+            // Re-enable foreign key constraints
+            console.log('\n🔧 Re-enabling foreign key constraints...');
+            try {
+              executeStagingD1('PRAGMA foreign_keys = ON;');
+              console.log('   ✅ Foreign key constraints re-enabled');
+            } catch (error) {
+              console.log('   ⚠️  Could not re-enable foreign key constraints');
+            }
             
             return { testRows, totalRows };
           }

--- a/scripts/run-prod-restore-to-staging.js
+++ b/scripts/run-prod-restore-to-staging.js
@@ -64,6 +64,15 @@ async function restoreProductionToStaging() {
     'enhanced_genres_backup', 'curated_genres', 'locations', 'users'
   ];
   
+  // Disable foreign key constraints for restore
+  console.log('🔧 Disabling foreign key constraints...');
+  try {
+    executeStagingD1Command('PRAGMA foreign_keys = OFF;');
+    console.log('  ✅ Foreign key constraints disabled');
+  } catch (error) {
+    console.log('  ⚠️  Could not disable foreign key constraints, proceeding anyway');
+  }
+  
   console.log('🗑️  Clearing staging tables...');
   
   // Clear tables in dependency order
@@ -141,6 +150,15 @@ async function restoreProductionToStaging() {
     } catch (error) {
       console.error(`    ❌ Failed to restore ${tableName}: ${error.message}`);
     }
+  }
+  
+  // Re-enable foreign key constraints
+  console.log('\n🔧 Re-enabling foreign key constraints...');
+  try {
+    executeStagingD1Command('PRAGMA foreign_keys = ON;');
+    console.log('  ✅ Foreign key constraints re-enabled');
+  } catch (error) {
+    console.log('  ⚠️  Could not re-enable foreign key constraints');
   }
   
   console.log('\n🎉 PRODUCTION DATA RESTORED TO STAGING!');

--- a/scripts/test-prod-restore-to-staging.js
+++ b/scripts/test-prod-restore-to-staging.js
@@ -215,6 +215,15 @@ class ProductionRestoreToStagingTest {
     ];
     
     try {
+      // Disable foreign key constraints for restore
+      console.log('🔧 Disabling foreign key constraints...');
+      try {
+        this.executeStagingD1Command('PRAGMA foreign_keys = OFF;');
+        console.log('  ✅ Foreign key constraints disabled');
+      } catch (error) {
+        console.log('  ⚠️  Could not disable foreign key constraints, proceeding anyway');
+      }
+      
       // Phase 1: Clear existing staging data
       console.log('🗑️  Phase 1: Clearing current staging data...');
       for (const tableName of tableOrder) {
@@ -298,6 +307,15 @@ class ProductionRestoreToStagingTest {
           console.error(`    ❌ Failed to restore ${tableName}: ${error.message}`);
           this.logAudit('TABLE_RESTORE_FAILED', `${tableName}: ${error.message}`);
         }
+      }
+      
+      // Re-enable foreign key constraints
+      console.log('\n🔧 Re-enabling foreign key constraints...');
+      try {
+        this.executeStagingD1Command('PRAGMA foreign_keys = ON;');
+        console.log('  ✅ Foreign key constraints re-enabled');
+      } catch (error) {
+        console.log('  ⚠️  Could not re-enable foreign key constraints');
       }
       
       console.log('\n🎉 PRODUCTION DATA RESTORED TO STAGING 🎉');


### PR DESCRIPTION
Fixes foreign key constraint violations during production backup restore to staging.

Changes:
- Disable foreign key constraints (PRAGMA foreign_keys = OFF) before restore operations
- Re-enable foreign key constraints (PRAGMA foreign_keys = ON) after restore completion
- Apply consistently across all restore scripts and GitHub Actions workflow
- Allows proper table clearing and data insertion despite foreign key dependencies

This resolves the remaining restore failures and completes the production-to-staging restore capability.

🤖 Generated with [Claude Code](https://claude.ai/code)