### PR TITLE
Add system user creation to fix curated_genres foreign key constraint

### DIFF
--- a/.github/workflows/test-restore-workflow-staging.yml
+++ b/.github/workflows/test-restore-workflow-staging.yml
@@ -273,6 +273,15 @@ jobs:
               }
             }
             
+            // Create system user for curated_genres foreign key constraint
+            console.log('👤 Creating system user for curated_genres...');
+            try {
+              executeStagingD1(`PRAGMA foreign_keys = OFF; INSERT INTO users (id, email, first_name, last_name, created_at, updated_at, password_hash, auth_provider, email_verified, user_role) VALUES ('system', 'system@library.local', 'System', 'User', '2025-01-01 00:00:00', '2025-01-01 00:00:00', NULL, 'system', 1, 'admin')`);
+              console.log('  ✅ System user created');
+            } catch (error) {
+              console.log('  ⚠️  Could not create system user, may already exist');
+            }
+            
             // Test restore on sample tables only (to avoid timeout)
             const testTables = ['curated_genres', 'locations', 'users']; // Test in reverse dependency order
             


### PR DESCRIPTION
Production curated_genres data has created_by = 'system' which violates the foreign key constraint in staging. Creates a system user before restoring curated_genres to resolve this schema difference.

🤖 Generated with [Claude Code](https://claude.ai/code)