### PR TITLE
Fix skipTables definition for sync process

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -244,7 +244,7 @@ jobs:
             
             // TEMPORARILY DISABLED: Clear staging tables for faster debugging
             console.log('⏭️  Skipping table clearing for faster debugging...');
-            // const skipTables = ['enhanced_genres_backup']; // Legacy table not in staging schema
+            const skipTables = ['enhanced_genres_backup']; // Legacy table not in staging schema
             // for (const tableName of tableOrder) {
             //   if (skipTables.includes(tableName)) {
             //     console.log(`    ⏭️  Skipping clear for ${tableName} (legacy/orphaned table)`);


### PR DESCRIPTION
Uncomment the skipTables variable definition since it's needed by the sync logic even when clearing is disabled.

🤖 Generated with [Claude Code](https://claude.ai/code)