### PR TITLE
Fix clearing and system user creation with file-based execution

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -255,7 +255,18 @@ jobs:
               
               if (backupData.tables[tableName] && !backupData.tables[tableName].error) {
                 try {
-                  executeStagingD1Command(`DELETE FROM ${tableName}`);
+                  // Use file-based execution for clearing too
+                  const clearSql = `DELETE FROM ${tableName};`;
+                  const tempFile = `./clear_${tableName}_${Date.now()}.sql`;
+                  const fs = require('fs');
+                  fs.writeFileSync(tempFile, clearSql);
+                  
+                  const result = execSync(`npx wrangler d1 execute librarycard-db-staging-new --config=wrangler.staging-new.toml --env=staging --remote --file="${tempFile}"`, {
+                    encoding: 'utf8',
+                    env: { ...process.env, CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN_STAGING_NEW }
+                  });
+                  
+                  fs.unlinkSync(tempFile);
                   console.log(`    ✅ Cleared ${tableName}`);
                 } catch (error) {
                   console.log(`    ⚠️  Could not clear ${tableName}: ${error.message}`);
@@ -266,7 +277,17 @@ jobs:
             // Create system user for curated_genres foreign key constraint
             console.log('\n👤 Creating system user for curated_genres...');
             try {
-              executeStagingD1Command(`INSERT INTO users (id, email, first_name, last_name, created_at, updated_at, password_hash, auth_provider, email_verified, user_role) VALUES ('system', 'system@library.local', 'System', 'User', '2025-01-01 00:00:00', '2025-01-01 00:00:00', NULL, 'system', 1, 'admin')`);
+              const systemUserSql = `INSERT INTO users (id, email, first_name, last_name, created_at, updated_at, password_hash, auth_provider, email_verified, user_role) VALUES ('system', 'system@library.local', 'System', 'User', '2025-01-01 00:00:00', '2025-01-01 00:00:00', NULL, 'system', 1, 'admin');`;
+              const tempFile = `./system_user_${Date.now()}.sql`;
+              const fs = require('fs');
+              fs.writeFileSync(tempFile, systemUserSql);
+              
+              const result = execSync(`npx wrangler d1 execute librarycard-db-staging-new --config=wrangler.staging-new.toml --env=staging --remote --file="${tempFile}"`, {
+                encoding: 'utf8',
+                env: { ...process.env, CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN_STAGING_NEW }
+              });
+              
+              fs.unlinkSync(tempFile);
               console.log('  ✅ System user created');
             } catch (error) {
               console.log('  ⚠️  Could not create system user, may already exist');


### PR DESCRIPTION
The executeStagingD1Command function doesn't exist, causing clearing and system user creation to fail silently. Replace with the same file-based execution approach used for data insertion.

This should properly clear tables and create the system user instead of failing silently.

🤖 Generated with [Claude Code](https://claude.ai/code)