### PR TITLE
Fix Jeremy SQL syntax error by using single quotes for JSON arrays

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -352,8 +352,8 @@ jobs:
                           try {
                             // Validate it's valid JSON first
                             JSON.parse(value);
-                            // If valid JSON, escape it for SQL (single layer of escaping)
-                            return JSON.stringify(value);
+                            // For JSON fields, use single quotes to avoid SQL parsing issues with square brackets
+                            return `'${value.replace(/'/g, "''")}'`;
                           } catch (parseError) {
                             // Not valid JSON despite field name or appearance, treat as regular string
                             console.log(`    ⚠️  Field ${col} looks like JSON but isn't valid: ${value.substring(0, 100)}...`);


### PR DESCRIPTION
CRITICAL FIX: Jeremy issue identified from preserved SQL file analysis

ROOT CAUSE: SQLite parsing confusion with double-quoted JSON arrays
- Before: "[\"Jeremy Robert Johnson\"]" (double quotes + JSON.stringify)
- After: '["Jeremy Robert Johnson"]' (single quotes + apostrophe escaping)

ISSUE: SQLite interprets [ character as special SQL syntax inside double quotes
SOLUTION: Use single quotes for JSON array fields to treat as literal strings

This should resolve the 'near Jeremy: syntax error at offset 567' completely.