### PR TITLE
Apply single quote escaping to ALL string fields to fix 'regions' error

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -360,14 +360,8 @@ jobs:
                           }
                         }
                         
-                        // Enhanced escaping for regular string fields
-                        try {
-                          return JSON.stringify(value);
-                        } catch (jsonError) {
-                          // Fallback: manual escaping for problematic strings
-                          console.log(`    ⚠️  JSON.stringify failed for ${col} in row ${rowIdx + 1}: ${jsonError.message}`);
-                          return `'${value.replace(/'/g, "''").replace(/\\/g, "\\\\")}'`;
-                        }
+                        // Use single quotes for ALL string fields to avoid SQL parsing issues
+                        return `'${value.replace(/'/g, "''")}'`;
                       }
                       if (typeof value === 'number') return value;
                       if (typeof value === 'boolean') return value ? 1 : 0;


### PR DESCRIPTION
PROGRESS: Jeremy fix worked! Advanced from batch 5/22 to batch 1/22
NEW ISSUE: 'near regions: syntax error at offset 1073' in book descriptions

ROOT CAUSE: Same SQL parsing confusion with complex text content
SOLUTION: Use single quotes for ALL string fields, not just JSON arrays

CHANGES:
- Remove JSON.stringify complexity entirely for strings
- Use simple single quote escaping: 'text content here'
- Only escape apostrophes: replace /'/g with ''
- Applies to titles, descriptions, all text fields

This should handle any problematic text content in book data.