### PR TITLE
CRITICAL: Apply single quote SQL escaping to ALL restore scripts

### DIFF
--- a/.github/workflows/staging-cloudflare-restore.yml
+++ b/.github/workflows/staging-cloudflare-restore.yml
@@ -290,8 +290,8 @@ jobs:
                 const val = row[col];
                 if (val === null || val === undefined) return 'NULL';
                 if (typeof val === 'string') {
-                  // Use JSON.stringify to properly escape all special characters including quotes, backslashes, etc.
-                  return JSON.stringify(val);
+                  // Use single quotes to avoid SQL parsing issues with complex text content
+                  return `'${val.replace(/'/g, "''")}'`;
                 }
                 return val;
               });

--- a/scripts/restore-backup.js
+++ b/scripts/restore-backup.js
@@ -288,8 +288,8 @@ class DatabaseRestore {
           const val = row[col];
           if (val === null || val === undefined) return 'NULL';
           if (typeof val === 'string') {
-            // Use JSON.stringify to properly escape all special characters including quotes, backslashes, etc.
-            return JSON.stringify(val);
+            // Use single quotes to avoid SQL parsing issues with complex text content
+            return `'${val.replace(/'/g, "''")}'`;
           }
           return val;
         });

--- a/scripts/restore-production.js
+++ b/scripts/restore-production.js
@@ -290,8 +290,8 @@ class ProductionDatabaseRestore {
               const value = row[col];
               if (value === null) return 'NULL';
               if (typeof value === 'string') {
-                // Use JSON.stringify to properly escape all special characters including quotes, backslashes, etc.
-                return JSON.stringify(value);
+                // Use single quotes to avoid SQL parsing issues with complex text content
+                return `'${value.replace(/'/g, "''")}'`;
               }
               return value;
             });

--- a/scripts/restore-staging.js
+++ b/scripts/restore-staging.js
@@ -336,8 +336,8 @@ class StagingDatabaseRestore {
           const val = row[col];
           if (val === null || val === undefined) return 'NULL';
           if (typeof val === 'string') {
-            // Use JSON.stringify to properly escape all special characters including quotes, backslashes, etc.
-            return JSON.stringify(val);
+            // Use single quotes to avoid SQL parsing issues with complex text content
+            return `'${val.replace(/'/g, "''")}'`;
           }
           return val;
         });


### PR DESCRIPTION
ISSUE: All restore scripts still had old JSON.stringify() escaping that would cause the same Jeremy/regions errors we just solved in the sync workflow.

FIXES APPLIED:
- scripts/restore-staging.js: Use single quotes instead of JSON.stringify
- scripts/restore-production.js: Use single quotes instead of JSON.stringify
- scripts/restore-backup.js: Use single quotes instead of JSON.stringify
- .github/workflows/staging-cloudflare-restore.yml: Use single quotes

CONSISTENCY: All backup/restore operations now use the same proven escaping approach that successfully synced 109 books with complex JSON/text content.

This prevents backup/restore failures on Jeremy book and other complex data.