### PR TITLE
Fix wrangler config file path in production restore workflow

### DIFF
--- a/.github/workflows/production-cloudflare-restore.yml
+++ b/.github/workflows/production-cloudflare-restore.yml
@@ -288,8 +288,8 @@ jobs:
               // Write SQL to temporary file
               writeFileSync(tempSqlFile, sql);
               
-              // Define command variable in broader scope
-              const command = `wrangler d1 execute librarycard-db --config=wrangler.prod.toml --env=production --remote --file="${tempSqlFile}"`;
+              // Define command variable in broader scope - use absolute path to config file
+              const command = `wrangler d1 execute librarycard-db --config=../../wrangler.prod.toml --env=production --remote --file="${tempSqlFile}"`;
               
               try {
                 // Execute using file instead of command parameter


### PR DESCRIPTION
CRITICAL PATH FIX:
- Changed config path from 'wrangler.prod.toml' to '../../wrangler.prod.toml'
- Restore script runs from restore-workspace/cloudflare/ directory
- Config file is actually in project root, not workspace
- This was the root cause of all "Could not read file" errors

The enhanced logging revealed wrangler was looking for: /home/runner/.../restore-workspace/cloudflare/wrangler.prod.toml But file is actually at:
/home/runner/.../wrangler.prod.toml

🤖 Generated with [Claude Code](https://claude.ai/code)