### PR TITLE
LCWEB-132 Remove unnecessary spacing in active filters area

### DIFF
--- a/src/components/library/ActiveFilters.tsx
+++ b/src/components/library/ActiveFilters.tsx
@@ -36,8 +36,7 @@ export default function ActiveFilters({
 
   return (
     <Box sx={{ 
-      mb: 3, 
-      minHeight: 48, // Reserve space for one row of chips (32px height + 16px gap)
+      mb: hasActiveFilters ? 3 : 0, 
       transition: 'opacity 0.3s ease-in-out, transform 0.3s ease-in-out',
       opacity: hasActiveFilters ? 1 : 0,
       transform: hasActiveFilters ? 'translateY(0)' : 'translateY(-8px)',


### PR DESCRIPTION
- Remove minHeight: 48 that reserved space even when no filters active
- Make bottom margin conditional (mb: hasActiveFilters ? 3 : 0)
- Eliminates empty space between filter controls and book listing
- Maintains proper spacing when filter chips are displayed

🤖 Generated with [Claude Code](https://claude.ai/code)