### PR TITLE
LCWEB-133 docs: Update commit workflow to use Jira instead of GitHub

### DIFF
--- a/.claude/commands/project/commit.md
+++ b/.claude/commands/project/commit.md
@@ -16,29 +16,29 @@ First, update all relevant project documentation:
 Follow the LibraryCard branch-based development workflow:
 - Run `git status` to see all changes
 - Run `git add .` to stage all changes
-- Create a descriptive commit message that follows project conventions (no AI attribution)
-- Commit the changes with `git commit -m "commit message"`
+- Create a descriptive commit message that follows project conventions (start with Jira ticket: "LCWEB-123 feat: description")
+- Commit the changes with `git commit -m "LCWEB-123 commit message"`
 - Run `git status` to confirm commit succeeded
 
 ## Pull Request Creation
 Create a pull request following LibraryCard standards:
 - Push the current branch to remote with `git push -u origin [branch-name]` 
 - Use `gh pr create` to create a pull request with:
-  - Clear title describing the work completed
+  - Clear title describing the work completed (include Jira ticket if applicable: "LCWEB-123 feat: description")
   - Body with "## Summary" section (1-3 bullet points)
   - Body with "## Test plan" section with testing checklist
-  - Include the GitHub issue link if working on a specific issue
+  - Include the Jira ticket reference if working on a specific ticket
 - Return the PR URL for easy access
 
-## GitHub Issue Updates
-If working on a specific GitHub issue, update it with progress:
-- Use `gh issue comment [issue-number]` to add a status update comment
+## Jira Issue Updates
+If working on a specific Jira ticket, update it with progress:
+- Use `jira issue edit LCWEB-123 --no-input` with progress comments
 - Include summary of changes implemented, technical details, and PR link
-- Mark issue resolution status (✅ Issue Resolved, 🚧 In Progress, etc.)
-- Provide clear documentation for future reference
+- Use `jira issue transition LCWEB-123 Done` when work is completed
+- Provide clear documentation for future reference with branch name and commit details
 
 ## Branch Management
 Follow LibraryCard branch conventions:
 - Ensure you're not on main branch (never commit directly to main)
-- Use proper branch naming: `feature/gh{issue-number}-{description}` or `feature/{description}`
+- Use proper branch naming: `LCWEB-{issue-number}-{description}` for Jira tickets or `feature/{description}` for non-issue work
 - Create PR targeting main branch for review


### PR DESCRIPTION
- Replace GitHub issue references with Jira ticket format (LCWEB-123)
- Update commit message format to include Jira ticket prefix
- Change issue management commands from gh CLI to jira CLI
- Update branch naming convention to LCWEB-{number}-{description}
- Align documentation with LibraryCard's Jira-based workflow