### PR TITLE
fix: Remove emoji from workflow name to resolve GitHub Actions displa…

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -1,4 +1,4 @@
-name: 🔄 Production Sync Data to Staging
+name: Production Sync Data to Staging
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
…y issue

GitHub Actions was showing the file path instead of the workflow name, likely due to unicode emoji characters in the workflow name causing parsing issues.