### PR TITLE
fix: Replace template literals with string concatenation in workflow …

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -171,22 +171,20 @@ jobs:
               }
               
               // Generate schema.sql file
-              const header = `-- Auto-generated production database schema
--- Extracted: ${new Date().toISOString()}
--- Source: Production database (librarycard-db)
--- 
--- This file is automatically updated during staging sync to ensure
--- staging database structure matches production exactly.
---
-
-`;
+              const header = '-- Auto-generated production database schema\n' +
+                           '-- Extracted: ' + new Date().toISOString() + '\n' +
+                           '-- Source: Production database (librarycard-db)\n' +
+                           '-- \n' +
+                           '-- This file is automatically updated during staging sync to ensure\n' +
+                           '-- staging database structure matches production exactly.\n' +
+                           '--\n\n';
               
               const schemaContent = header + schemaStatements.join('\n\n') + '\n';
               
               fs.writeFileSync('schema.sql', schemaContent);
               
-              console.log(`✅ Generated schema.sql with ${schemaStatements.length} table definitions`);
-              console.log(`📊 Schema file size: ${schemaContent.length} characters`);
+              console.log('✅ Generated schema.sql with ' + schemaStatements.length + ' table definitions');
+              console.log('📊 Schema file size: ' + schemaContent.length + ' characters');
               
               // Show which tables were captured
               console.log('📋 Tables extracted from production:');


### PR DESCRIPTION
…YAML

YAML parsers have issues with JavaScript template literals (backticks) inside heredoc blocks. This was preventing GitHub Actions from parsing the workflow properly, causing the missing 'Run workflow' button.

Changed to standard string concatenation to ensure YAML compatibility.