### PR TITLE
fix: Define skipTables array to resolve staging sync JavaScript error

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -326,6 +326,12 @@ jobs:
               'curated_genres', 'locations', 'users'
             ];
             
+            // Define tables to skip (legacy/orphaned/problematic tables)
+            const skipTables = [
+              'sqlite_sequence',
+              'sqlite_master'
+            ];
+            
             console.log('🗑️💥 DROPPING AND RECREATING STAGING DATABASE...');
             console.log('    This is faster and more reliable than clearing individual tables');
             


### PR DESCRIPTION
- Fixes 'skipTables is not defined' error in production to staging sync workflow
- Adds skipTables array with sqlite system tables to skip during sync
- Resolves immediate blocking issue preventing staging sync completion