### PR TITLE
feat: Disable foreign key constraints during bulk sync operations

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -472,6 +472,15 @@ jobs:
             
             console.log('\n📥 Syncing ALL production data to staging...');
             
+            // DISABLE foreign key constraints during sync
+            console.log('🔧 Disabling foreign key constraints for bulk sync...');
+            try {
+              executeStagingD1Command('PRAGMA foreign_keys = OFF;');
+              console.log('✅ Foreign key constraints disabled');
+            } catch (error) {
+              console.log('⚠️  Could not disable foreign key constraints:', error.message);
+            }
+            
             // Sync in correct order: parents first, then children  
             // tableOrder is now defined with parents first, so use as-is
             const syncOrder = [...tableOrder];
@@ -831,8 +840,14 @@ jobs:
               }
             }
             
-            // Foreign key constraints are automatically handled by fresh schema
-            console.log('\n✅ Foreign key constraints automatically configured by fresh schema');
+            // RE-ENABLE foreign key constraints after sync
+            console.log('\n🔧 Re-enabling foreign key constraints after sync...');
+            try {
+              executeStagingD1Command('PRAGMA foreign_keys = ON;');
+              console.log('✅ Foreign key constraints re-enabled');
+            } catch (error) {
+              console.log('⚠️  Could not re-enable foreign key constraints:', error.message);
+            }
             
             console.log('\n🎉 PRODUCTION DATA COMPLETELY SYNCED TO STAGING!');
             console.log('=====================================================');


### PR DESCRIPTION
- Add PRAGMA foreign_keys = OFF before starting data sync
- Re-enable PRAGMA foreign_keys = ON after sync completion
- Allows sync to proceed without foreign key constraint validation
- Prevents 'no such table: main.books' errors during bulk import
- Common pattern for database migrations and bulk data operations

This should resolve the foreign key dependency issues that were preventing the sync from completing when child tables were synced before all parent tables were fully established.