### PR TITLE
feat: Remove foreign key constraints from book tables during creation

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -565,8 +565,17 @@ jobs:
                       const tableMatch = schemaContent.match(tableRegex);
                       
                       if (tableMatch) {
-                        const createTableSql = tableMatch[0];
+                        let createTableSql = tableMatch[0];
                         console.log(`    📋 Found CREATE statement for ${tableName}`);
+                        
+                        // For problematic tables, remove foreign key constraints temporarily
+                        if (['book_ratings', 'book_checkout_history', 'book_removal_requests', 'book_genres'].includes(tableName)) {
+                          console.log(`    🔧 Removing foreign key constraints from ${tableName} for sync`);
+                          // Remove REFERENCES clauses from the CREATE statement
+                          createTableSql = createTableSql.replace(/REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
+                          // Remove FOREIGN KEY constraints  
+                          createTableSql = createTableSql.replace(/,\s*FOREIGN\s+KEY\s*\([^)]+\)\s+REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
+                        }
                         
                         // Create temporary SQL file and execute it
                         const tempFile = `./create_${tableName}_${Date.now()}.sql`;


### PR DESCRIPTION
- Strip REFERENCES clauses from CREATE statements for book-related tables
- Remove FOREIGN KEY constraints from problematic tables during sync
- Target specific tables: book_ratings, book_checkout_history, book_removal_requests, book_genres
- Allow these tables to be created and synced without foreign key dependencies
- Temporary workaround until books table sync issue is resolved

This should allow book_ratings and other book-dependent tables to sync successfully even when the books table is missing or not yet synced.