### PR TITLE
fix: Improve foreign key constraint removal regex patterns

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -571,10 +571,23 @@ jobs:
                         // For problematic tables, remove foreign key constraints temporarily
                         if (['book_ratings', 'book_checkout_history', 'book_removal_requests', 'book_genres'].includes(tableName)) {
                           console.log(`    🔧 Removing foreign key constraints from ${tableName} for sync`);
-                          // Remove REFERENCES clauses from the CREATE statement
-                          createTableSql = createTableSql.replace(/REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
-                          // Remove FOREIGN KEY constraints  
+                          console.log(`    🔍 Original SQL length: ${createTableSql.length}`);
+                          
+                          // More careful regex to remove REFERENCES without breaking syntax
+                          // Remove REFERENCES clauses (but preserve column definition)
+                          createTableSql = createTableSql.replace(/\s+REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
+                          
+                          // Remove standalone FOREIGN KEY constraints (full constraint lines)
+                          createTableSql = createTableSql.replace(/,\s*CONSTRAINT\s+\w+\s+FOREIGN\s+KEY\s*\([^)]+\)\s+REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
                           createTableSql = createTableSql.replace(/,\s*FOREIGN\s+KEY\s*\([^)]+\)\s+REFERENCES\s+\w+\s*\([^)]+\)(\s+[A-Z\s]+)?/gi, '');
+                          
+                          // Clean up any double commas
+                          createTableSql = createTableSql.replace(/,\s*,/g, ',');
+                          // Clean up trailing commas before closing parenthesis
+                          createTableSql = createTableSql.replace(/,\s*\)/g, ')');
+                          
+                          console.log(`    🔍 Modified SQL length: ${createTableSql.length}`);
+                          console.log(`    🔍 Modified SQL preview: ${createTableSql.substring(0, 200)}...`);
                         }
                         
                         // Create temporary SQL file and execute it


### PR DESCRIPTION
- More precise regex to remove REFERENCES clauses without breaking syntax
- Add CONSTRAINT removal for named foreign key constraints
- Clean up double commas and trailing commas after regex operations
- Add debugging output to show original vs modified SQL
- Prevent 'near comma' syntax errors in CREATE TABLE statements

This should resolve the SQL syntax errors that were preventing book_ratings, book_removal_requests, and book_checkout_history tables from being created successfully.