### PR TITLE
LCWEB-13 fix: Remove unused book notes columns and author_mappings re…

### DIFF
--- a/.github/workflows/sync-production-to-staging.yml
+++ b/.github/workflows/sync-production-to-staging.yml
@@ -470,7 +470,7 @@ jobs:
             const criticalMissingTables = [];
             
             // Critical tables that must be synced for app to work
-            const criticalTables = ['users', 'locations', 'books', 'curated_genres', 'author_mappings'];
+            const criticalTables = ['users', 'locations', 'books', 'curated_genres'];
             
             // First, show ALL tables in backup for debugging
             console.log('📋 ALL TABLES IN BACKUP DATA:');

--- a/migrations/20250903_drop_unused_book_notes_columns.sql
+++ b/migrations/20250903_drop_unused_book_notes_columns.sql
@@ -1,0 +1,11 @@
+-- Drop unused personal notes feature columns from books table
+-- These columns were added in 20250816_add_book_notes_feature.sql but never implemented in the UI/API
+-- Removing to clean up schema and fix staging sync column mismatch issues
+
+-- Drop the index first
+DROP INDEX IF EXISTS idx_books_personal_notes;
+
+-- Drop the unused columns
+ALTER TABLE books DROP COLUMN personal_notes;
+ALTER TABLE books DROP COLUMN notes_visibility;
+ALTER TABLE books DROP COLUMN last_notes_updated;


### PR DESCRIPTION
…ferences

- Add migration to drop unused personal_notes, notes_visibility, last_notes_updated columns from books table
- These columns were added in Aug 2025 migration but never implemented in UI/API
- Remove author_mappings from critical tables list (table doesn't exist in production)
- This fixes the staging sync column mismatch and missing table issues