### PR TITLE
LCWEB-147 fix: Export API_BASE_URL as function call instead of functi…

### DIFF
--- a/src/lib/apiConfig.ts
+++ b/src/lib/apiConfig.ts
@@ -16,4 +16,4 @@ export const getApiBaseUrl = (): string => {
 }
 
 // Export the function directly to avoid computing during build
-export const API_BASE_URL = getApiBaseUrl
+export const API_BASE_URL = getApiBaseUrl()


### PR DESCRIPTION
…on reference

- Changed API_BASE_URL from getApiBaseUrl to getApiBaseUrl()
- Fixes password reset 500 errors caused by invalid URL construction
- Resolves 'Failed to parse URL' error in Next.js API routes
- Tested locally and staging environments