### PR TITLE
LCWEB-148 fix: Remove BEGIN/COMMIT statements from D1 migration

### DIFF
--- a/migrations/20250816_add_rollback_support.sql
+++ b/migrations/20250816_add_rollback_support.sql
@@ -8,7 +8,6 @@ PRAGMA table_info(migration_batches);
 
 -- Use CREATE TABLE to recreate with the rollback_target column if needed
 -- This is safe because if the column already exists, the bootstrap system will handle gracefully
-BEGIN;
 
 -- Create new table with rollback_target column
 CREATE TABLE IF NOT EXISTS migration_batches_with_rollback (
@@ -40,8 +39,6 @@ ALTER TABLE migration_batches_with_rollback RENAME TO migration_batches;
 -- Recreate indexes
 CREATE INDEX IF NOT EXISTS idx_migration_batches_status ON migration_batches(status);
 CREATE INDEX IF NOT EXISTS idx_migration_batches_started_at ON migration_batches(started_at);
-
-COMMIT;
 
 -- Create rollback tracking table (optional, for detailed rollback history)
 CREATE TABLE IF NOT EXISTS migration_rollbacks (


### PR DESCRIPTION
- Remove explicit transaction statements from 20250816_add_rollback_support.sql
- Cloudflare D1 doesn't allow SQL transaction statements
- Fixes staging deployment migration failure with 'use state.storage.transaction()' error
- Migration operations will be handled by D1's automatic transaction management