### PR TITLE
LCWEB-148 fix: Make API_BASE_URL usage consistent across all API routes

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Forward to Workers API
-    const response = await fetch(`${API_BASE_URL}/api/auth/forgot-password`, {
+    const response = await fetch(`${API_BASE_URL()}/api/auth/forgot-password`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Forward to Workers API
-    const response = await fetch(`${API_BASE_URL}/api/auth/reset-password`, {
+    const response = await fetch(`${API_BASE_URL()}/api/auth/reset-password`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/app/api/auth/verify-reset-token/route.ts
+++ b/src/app/api/auth/verify-reset-token/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Forward to Workers API
-    const response = await fetch(`${API_BASE_URL}/api/auth/verify-reset-token?token=${encodeURIComponent(token)}`, {
+    const response = await fetch(`${API_BASE_URL()}/api/auth/verify-reset-token?token=${encodeURIComponent(token)}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/lib/apiConfig.ts
+++ b/src/lib/apiConfig.ts
@@ -16,4 +16,4 @@ export const getApiBaseUrl = (): string => {
 }
 
 // Export the function directly to avoid computing during build
-export const API_BASE_URL = getApiBaseUrl()
+export const API_BASE_URL = getApiBaseUrl


### PR DESCRIPTION
- Export API_BASE_URL as function reference (not function call)
- Update all API routes to call API_BASE_URL() consistently
- Fixes TypeScript build error: 'Type String has no call signatures'
- Ensures staging deployment can complete successfully
- Resolves password reset 500 errors caused by deployment failures