### PR TITLE
LCWEB-147 fix: Export API_BASE_URL as function wrapper to prevent ser…

### DIFF
--- a/src/lib/apiConfig.ts
+++ b/src/lib/apiConfig.ts
@@ -15,5 +15,5 @@ export const getApiBaseUrl = (): string => {
   return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8787'
 }
 
-// Export the function directly to avoid computing during build
-export const API_BASE_URL = getApiBaseUrl
+// Export function wrapper to avoid build-time evaluation issues
+export const API_BASE_URL = () => getApiBaseUrl()


### PR DESCRIPTION
…ialization

- Change API_BASE_URL export from direct function reference to wrapper function
- Fixes production error where function was serialized to string during build
- Ensures proper runtime evaluation of environment variables
- Resolves "Failed to parse URL from ()=>{...}" error in password reset flow