### PR TITLE
LCWEB-151 fix: Unified notification badge state management and cache …

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -26,6 +26,7 @@ import {
   LibraryBooks,
 } from '@mui/icons-material'
 import { getApiBaseUrl } from '@/lib/apiConfig'
+import { useAdminPendingCounts } from '@/hooks/useAdminPendingCounts'
 
 // Lazy load admin components for better performance
 const AdminAnalytics = lazy(() => import('./AdminAnalytics'))
@@ -88,6 +89,7 @@ export default function AdminDashboard({ initialTab, onDataChange }: AdminDashbo
   const [dataLoaded, setDataLoaded] = useState(false)
   const [fadeIn, setFadeIn] = useState(true)
   const [isTransitioning, setIsTransitioning] = useState(false)
+  const { counts: adminCounts } = useAdminPendingCounts()
 
   useEffect(() => {
     // Only run on initial mount to set tab from URL/prop
@@ -272,7 +274,7 @@ export default function AdminDashboard({ initialTab, onDataChange }: AdminDashbo
           <Tab 
             icon={
               <Badge 
-                badgeContent={(overview?.pendingRequests || 0) + (overview?.pendingReviews || 0) + (overview?.pendingSignupRequests || 0) > 0 ? (overview?.pendingRequests || 0) + (overview?.pendingReviews || 0) + (overview?.pendingSignupRequests || 0) : undefined} 
+                badgeContent={adminCounts.total > 0 ? adminCounts.total : undefined} 
                 color="primary"
                 max={99}
                 sx={{

--- a/src/components/admin/AdminNotificationCenter.tsx
+++ b/src/components/admin/AdminNotificationCenter.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useSession } from 'next-auth/react'
 import {
   Typography,
@@ -24,6 +24,7 @@ import GenreRequestManager from './GenreRequestManager'
 import AdminSignupManager from './AdminSignupManager'
 import { lazy, Suspense } from 'react'
 import { getApiBaseUrl } from '@/lib/apiConfig'
+import { useAdminPendingCounts } from '@/hooks/useAdminPendingCounts'
 
 const ReviewModeration = lazy(() => import('./ReviewModerationComponent'))
 const AdminSeriesReview = lazy(() => import('./AdminSeriesReview'))
@@ -46,48 +47,18 @@ interface AdminNotificationCenterProps {
 export default function AdminNotificationCenter({ onDataChange }: AdminNotificationCenterProps = {}) {
   const { data: session } = useSession()
   const [activeTab, setActiveTab] = useState(0)
-  const [counts, setCounts] = useState<NotificationCounts>({
-    pendingRemovalRequests: 0,
-    pendingReviews: 0,
-    pendingSignupRequests: 0,
-    overdueCheckouts: 0,
-    monthlyReminders: 0,
-    pendingInvitations: 0,
-    pendingGenreRequests: 0,
-    pendingSeries: 0
-  })
+  const { counts: adminCounts, refreshCounts } = useAdminPendingCounts()
+  const [genreRequests, setGenreRequests] = useState(0)
   const [dataLoaded, setDataLoaded] = useState(false)
-
-  useEffect(() => {
-    if (session?.user?.email && !dataLoaded) {
-      loadNotificationCounts()
-      setDataLoaded(true)
-    }
-  }, [session?.user?.email, dataLoaded])
-
-  const loadNotificationCounts = async () => {
+  
+  const loadNotificationCounts = useCallback(async () => {
     if (!session?.user?.email) return
 
     try {
-      // Load analytics data to get pending requests count
-      const analyticsResponse = await fetch(`${getApiBaseUrl()}/api/admin/analytics`, {
-        headers: {
-          'Authorization': `Bearer ${session.user.email}`,
-          'Content-Type': 'application/json',
-        },
-      })
+      // Refresh the shared admin counts (handles pendingRequests, pendingReviews, pendingSignupRequests, pendingSeries)
+      await refreshCounts()
 
-      if (analyticsResponse.ok) {
-        const analyticsData = await analyticsResponse.json()
-        setCounts(prev => ({
-          ...prev,
-          pendingRemovalRequests: analyticsData.overview.pendingRequests || 0,
-          pendingReviews: analyticsData.overview.pendingReviews || 0,
-          pendingSignupRequests: analyticsData.overview.pendingSignupRequests || 0
-        }))
-      }
-
-      // Load genre requests count
+      // Load genre requests count separately (not included in shared hook yet)
       const genreRequestsResponse = await fetch(`${getApiBaseUrl()}/api/admin/genre-requests`, {
         headers: {
           'Authorization': `Bearer ${session.user.email}`,
@@ -96,28 +67,9 @@ export default function AdminNotificationCenter({ onDataChange }: AdminNotificat
       })
 
       if (genreRequestsResponse.ok) {
-        const genreRequests = await genreRequestsResponse.json()
-        const pendingCount = genreRequests.filter((req: any) => req.status === 'pending').length
-        setCounts(prev => ({
-          ...prev,
-          pendingGenreRequests: pendingCount
-        }))
-      }
-
-      // Load pending series count
-      const seriesResponse = await fetch(`${getApiBaseUrl()}/api/admin/analytics`, {
-        headers: {
-          'Authorization': `Bearer ${session.user.email}`,
-          'Content-Type': 'application/json',
-        },
-      })
-
-      if (seriesResponse.ok) {
-        const seriesData = await seriesResponse.json()
-        setCounts(prev => ({
-          ...prev,
-          pendingSeries: seriesData.overview.pendingSeries || 0
-        }))
+        const genreRequestsData = await genreRequestsResponse.json()
+        const pendingCount = genreRequestsData.filter((req: any) => req.status === 'pending').length
+        setGenreRequests(pendingCount)
       }
 
       // TODO: Implement other notification counts when features are added
@@ -131,7 +83,26 @@ export default function AdminNotificationCenter({ onDataChange }: AdminNotificat
     } catch (error) {
       console.error('Error loading notification counts:', error)
     }
+  }, [session?.user?.email, refreshCounts, onDataChange])
+
+  // Map shared counts to local counts interface for backwards compatibility
+  const counts = {
+    pendingRemovalRequests: adminCounts.pendingRequests,
+    pendingReviews: adminCounts.pendingReviews,
+    pendingSignupRequests: adminCounts.pendingSignupRequests,
+    pendingSeries: adminCounts.pendingSeries,
+    pendingGenreRequests: genreRequests,
+    overdueCheckouts: 0,
+    monthlyReminders: 0,
+    pendingInvitations: 0
   }
+
+  useEffect(() => {
+    if (session?.user?.email && !dataLoaded) {
+      loadNotificationCounts()
+      setDataLoaded(true)
+    }
+  }, [session?.user?.email, dataLoaded, loadNotificationCounts])
 
   // Set up automatic refresh every 30 seconds for dynamic updates
   useEffect(() => {
@@ -254,7 +225,7 @@ export default function AdminNotificationCenter({ onDataChange }: AdminNotificat
           {activeTab === 4 && (
             <Box sx={{ p: 3 }}>
               <Suspense fallback={<Box sx={{ p: 3, textAlign: 'center' }}>Loading series reviews...</Box>}>
-                <AdminSeriesReview />
+                <AdminSeriesReview onCountChange={loadNotificationCounts} />
               </Suspense>
             </Box>
           )}

--- a/src/components/admin/AdminSeriesReview.tsx
+++ b/src/components/admin/AdminSeriesReview.tsx
@@ -165,7 +165,11 @@ function ReviewDialog({ series, open, onClose, onSubmit }: ReviewDialogProps) {
   )
 }
 
-export default function AdminSeriesReview() {
+interface AdminSeriesReviewProps {
+  onCountChange?: () => void;
+}
+
+export default function AdminSeriesReview({ onCountChange }: AdminSeriesReviewProps = {}) {
   const { data: session } = useSession()
   const [pendingSeries, setPendingSeries] = useState<PendingSeries[]>([])
   const [loading, setLoading] = useState(true)
@@ -235,6 +239,12 @@ export default function AdminSeriesReview() {
         
         // Close the dialog
         setReviewDialog({ open: false, series: null })
+        
+        // Notify parent component to refresh counts with a small delay 
+        // to ensure database changes are reflected
+        setTimeout(() => {
+          onCountChange?.()
+        }, 100)
         
         setError('')
       } else {

--- a/workers/admin-extended/index.ts
+++ b/workers/admin-extended/index.ts
@@ -30,6 +30,9 @@ export async function getAdminAnalytics(userId: string, env: Env, corsHeaders: R
       pendingReviews = await env.DB.prepare('SELECT COUNT(*) as count FROM book_ratings WHERE review_status = "pending"').first();
       pendingSignupRequests = await env.DB.prepare('SELECT COUNT(*) as count FROM signup_approval_requests WHERE status = "pending"').first();
       pendingSeries = await env.DB.prepare('SELECT COUNT(*) as count FROM series WHERE approval_status = "pending"').first();
+      
+      // DEBUG: Log the pendingSeries query result for super admin
+      console.log('DEBUG - Super admin pendingSeries result:', pendingSeries);
     } else {
       // Regular admin gets location-scoped statistics
       totalBooks = await env.DB.prepare(`
@@ -320,6 +323,9 @@ export async function getAdminAnalytics(userId: string, env: Env, corsHeaders: R
 
     // Disable duplicate detection for now - no actual duplicates exist
     const duplicates = { results: [] };
+
+    // DEBUG: Log final pendingSeries value before response
+    console.log('DEBUG - Final pendingSeries before response:', pendingSeries, 'count:', (pendingSeries as any)?.count);
 
     return new Response(JSON.stringify({
       overview: {

--- a/workers/series/index.ts
+++ b/workers/series/index.ts
@@ -132,6 +132,17 @@ export async function createSeries(request: Request, userId: string, env: Env, c
       approvalStatus
     ).run();
     
+    // Invalidate admin analytics cache if series is pending (affects pendingSeries count)
+    if (approvalStatus === 'pending') {
+      try {
+        const { invalidateAllAdminAnalytics } = await import('../admin/cached');
+        await invalidateAllAdminAnalytics(env);
+      } catch (cacheError) {
+        console.error('Failed to invalidate admin analytics cache:', cacheError);
+        // Don't fail the creation if cache invalidation fails
+      }
+    }
+
     // Return the created series
     const newSeries = {
       id: seriesId,
@@ -643,6 +654,15 @@ export async function approveRejectSeries(
     `);
     
     const updatedSeries = await updatedStmt.bind(seriesId).first();
+
+    // Invalidate admin analytics cache since pendingSeries count changed
+    try {
+      const { invalidateAllAdminAnalytics } = await import('../admin/cached');
+      await invalidateAllAdminAnalytics(env);
+    } catch (cacheError) {
+      console.error('Failed to invalidate admin analytics cache:', cacheError);
+      // Don't fail the approval if cache invalidation fails
+    }
 
     return new Response(JSON.stringify({
       success: true,


### PR DESCRIPTION
…invalidation

**Root Cause:**
- AdminNotificationCenter used local state instead of shared useAdminPendingCounts hook
- AdminDashboard Notifications tab calculated badges manually, excluding pendingSeries
- Series operations didn't invalidate admin analytics cache, causing stale data

**Frontend Fixes:**
- AdminNotificationCenter now uses shared useAdminPendingCounts hook for consistent state
- AdminDashboard Notifications tab uses adminCounts.total from shared hook
- AdminSeriesReview added onCountChange callback with 100ms delay for DB timing
- All admin notification badges now use unified state management

**Backend Fixes:**
- Added invalidateAllAdminAnalytics() to series creation (pending status)
- Added invalidateAllAdminAnalytics() to series approval/rejection operations
- Added debug logging to track pendingSeries query execution

**Result:**
- Series Reviews tab badge updates immediately after approval actions
- Admin nav badge and Notifications tab badge update on page refresh
- All badge counts now consistent across GlobalHeader, AdminDashboard, and sub-tabs

🤖 Generated with [Claude Code](https://claude.ai/code)