### PR TITLE
LCWEB-154 fix: Mark verify-reset-token route as dynamic to prevent bu…

### DIFF
--- a/src/app/api/auth/verify-reset-token/route.ts
+++ b/src/app/api/auth/verify-reset-token/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { API_BASE_URL } from '@/lib/apiConfig'
 
+// Force dynamic rendering since this route needs to read query parameters
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     const token = request.nextUrl.searchParams.get('token')


### PR DESCRIPTION
…ild error

Added 'export const dynamic = force-dynamic' to properly handle the route that reads query parameters.

This eliminates the dynamic server usage error during build by explicitly telling Next.js that this route should be rendered dynamically rather than attempting static generation.