### PR TITLE
LCWEB-7 feat: Add conditional cover attribution for Google Books and …

### DIFF
--- a/src/components/common/CoverAttribution.tsx
+++ b/src/components/common/CoverAttribution.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { Box, Typography, Link } from '@mui/material'
+import { Book, Public } from '@mui/icons-material'
+
+interface CoverAttributionProps {
+  coverUrl?: string
+  variant?: 'small' | 'default'
+}
+
+/**
+ * Detects the source of a book cover URL and provides appropriate attribution
+ */
+function detectCoverSource(coverUrl: string): 'google' | 'openlibrary' | 'unknown' {
+  if (coverUrl.includes('books.google.com') || coverUrl.includes('books.googleusercontent.com')) {
+    return 'google'
+  }
+  if (coverUrl.includes('covers.openlibrary.org')) {
+    return 'openlibrary'
+  }
+  return 'unknown'
+}
+
+export default function CoverAttribution({ coverUrl, variant = 'default' }: CoverAttributionProps) {
+  // Don't show attribution if no cover URL
+  if (!coverUrl) {
+    return null
+  }
+
+  const source = detectCoverSource(coverUrl)
+  
+  // Don't show attribution for unknown sources
+  if (source === 'unknown') {
+    return null
+  }
+
+  const isSmall = variant === 'small'
+  const fontSize = isSmall ? '0.7rem' : '0.75rem'
+  const iconSize = isSmall ? 12 : 14
+
+  if (source === 'google') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: isSmall ? 0.5 : 1 }}>
+        <Book sx={{ fontSize: iconSize, color: 'text.secondary' }} />
+        <Typography 
+          variant="caption" 
+          color="text.secondary"
+          sx={{ fontSize }}
+        >
+          Cover from{' '}
+          <Link 
+            href="https://books.google.com" 
+            target="_blank" 
+            rel="noopener noreferrer"
+            color="primary"
+            sx={{ textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+          >
+            Google Books
+          </Link>
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (source === 'openlibrary') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: isSmall ? 0.5 : 1 }}>
+        <Public sx={{ fontSize: iconSize, color: 'text.secondary' }} />
+        <Typography 
+          variant="caption" 
+          color="text.secondary"
+          sx={{ fontSize }}
+        >
+          Cover from{' '}
+          <Link 
+            href="https://openlibrary.org" 
+            target="_blank" 
+            rel="noopener noreferrer"
+            color="secondary"
+            sx={{ textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
+          >
+            Open Library
+          </Link>
+        </Typography>
+      </Box>
+    )
+  }
+
+  return null
+}

--- a/src/components/modals/MoreDetailsModal.tsx
+++ b/src/components/modals/MoreDetailsModal.tsx
@@ -31,6 +31,7 @@ import { useSession } from 'next-auth/react'
 import { authenticatedFetch } from '@/lib/auth-utils'
 import { useSeries } from '@/hooks/useSeries'
 import SeriesModal from './SeriesModal'
+import CoverAttribution from '@/components/common/CoverAttribution'
 
 interface CheckoutHistoryItem {
   id: number
@@ -273,6 +274,7 @@ export default function MoreDetailsModal({ book, isOpen, onClose, userRole, user
                     boxShadow: '0 4px 8px rgba(0,0,0,0.1)'
                   }}
                 />
+                <CoverAttribution coverUrl={book.thumbnail} variant="small" />
               </Box>
             )}
             

--- a/src/components/modals/RatingModal.tsx
+++ b/src/components/modals/RatingModal.tsx
@@ -17,6 +17,7 @@ import { Close, Star } from '@mui/icons-material'
 import type { EnhancedBook } from '@/lib/types'
 import StarRatingInput from '../book/StarRatingInput'
 import AccessibleIcon from '../ui/AccessibleIcon'
+import CoverAttribution from '../common/CoverAttribution'
 
 interface RatingModalProps {
   book: EnhancedBook
@@ -107,18 +108,21 @@ export default function RatingModal({
         {/* Book Info */}
         <Box sx={{ mb: 3, display: 'flex', gap: 2 }}>
           {book.thumbnail && (
-            <Box
-              component="img"
-              src={book.thumbnail}
-              alt={book.title}
-              sx={{ 
-                width: 60, 
-                height: 90, 
-                objectFit: 'cover',
-                borderRadius: 1,
-                flexShrink: 0
-              }}
-            />
+            <Box sx={{ flexShrink: 0 }}>
+              <Box
+                component="img"
+                src={book.thumbnail}
+                alt={book.title}
+                sx={{ 
+                  width: 60, 
+                  height: 90, 
+                  objectFit: 'cover',
+                  borderRadius: 1,
+                  display: 'block'
+                }}
+              />
+              <CoverAttribution coverUrl={book.thumbnail} variant="small" />
+            </Box>
           )}
           <Box sx={{ flex: 1 }}>
             <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>


### PR DESCRIPTION
…OpenLibrary

- Create CoverAttribution component with automatic source detection
- Add attribution links to MoreDetailsModal and RatingModal
- Ensure compliance with Google Books API and OpenLibrary terms of service
- Support both small and default variants for different display contexts
- Include clickable attribution links with appropriate icons