### PR TITLE
LCWEB-159 feat: Change default theme to forest green/light

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## September 5, 2025 - Default Theme Update - LCWEB-159
+
+### 🎨 UI Enhancement: Changed Default Theme to Forest Green/Light
+**LCWEB-159** completed - Updated the default theme configuration from indigo/dark to forest green/light for improved user experience and brand alignment.
+
+#### Changes Made ✅
+- **Theme Configuration**: Updated `src/lib/theme.ts` to use forest green as default theme variant
+- **Context Provider**: Modified `src/lib/ThemeContext.tsx` to default to light mode and green variant
+- **New User Experience**: New users now get forest green/light theme by default
+- **Existing Users**: Preserved all existing user theme preferences unchanged
+- **Fallback Logic**: Added proper fallback logic to ensure green theme for users without saved preferences
+
+#### Technical Details ✅
+- **Files Modified**: `src/lib/theme.ts` and `src/lib/ThemeContext.tsx`
+- **Default Parameters**: Updated function defaults from `'indigo'` to `'green'`
+- **Theme Mode**: Changed initial state from `isDarkMode: true` to `isDarkMode: false`
+- **Backward Compatibility**: Maintained all existing theme functionality and user preferences
+- **Build Verification**: Confirmed successful build and lint validation
+
 ## September 1, 2025 - Series System Implementation - LCWEB-13
 
 ### 🚀 Major Feature: Series System for Book Organization

--- a/src/lib/ThemeContext.tsx
+++ b/src/lib/ThemeContext.tsx
@@ -31,8 +31,8 @@ interface ThemeContextProviderProps {
 }
 
 export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
-  const [isDarkMode, setIsDarkMode] = useState(true)
-  const [themeVariant, setThemeVariant] = useState<ThemeVariant>('indigo')
+  const [isDarkMode, setIsDarkMode] = useState(false)
+  const [themeVariant, setThemeVariant] = useState<ThemeVariant>('green')
   const [isLoaded, setIsLoaded] = useState(false)
 
   // Load theme preferences from localStorage on mount
@@ -43,14 +43,17 @@ export function ThemeContextProvider({ children }: ThemeContextProviderProps) {
     if (savedTheme === 'light') {
       setIsDarkMode(false)
     } else if (!savedTheme) {
-      // Default to dark mode for new users
-      setIsDarkMode(true)
+      // Default to light mode for new users
+      setIsDarkMode(false)
     } else {
       setIsDarkMode(savedTheme === 'dark')
     }
     
     if (savedVariant && ['indigo', 'green', 'red', 'blue', 'purple', 'amber'].includes(savedVariant)) {
       setThemeVariant(savedVariant)
+    } else if (!savedVariant) {
+      // Default to forest green for new users
+      setThemeVariant('green')
     }
     
     setIsLoaded(true)

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1186,13 +1186,13 @@ function createThemeOptions(isDark: boolean, variant: ThemeVariant): ThemeOption
   return isDark ? darkThemeOptions : lightThemeOptions
 }
 
-export const lightTheme = createTheme(createThemeOptions(false, 'indigo'))
-export const darkTheme = createTheme(createThemeOptions(true, 'indigo'))
+export const lightTheme = createTheme(createThemeOptions(false, 'green'))
+export const darkTheme = createTheme(createThemeOptions(true, 'green'))
 
 // Export default theme for backwards compatibility
 export const theme = lightTheme
 
-export function createAppTheme(isDark: boolean, variant: ThemeVariant = 'indigo') {
+export function createAppTheme(isDark: boolean, variant: ThemeVariant = 'green') {
   return createTheme(createThemeOptions(isDark, variant))
 }
 


### PR DESCRIPTION
## Summary
- Changed default theme configuration from indigo/dark to forest green/light
- Updated theme.ts and ThemeContext.tsx to use green variant and light mode by default
- Added proper fallback logic to ensure new users get the forest green theme
- Preserved all existing user theme preferences unchanged

## Test plan
- [x] Verify build completes successfully 
- [x] Verify lint passes without errors
- [x] Confirm new users get forest green/light theme by default
- [x] Verify existing users retain their saved theme preferences
- [x] Test theme switching functionality still works correctly
- [x] Updated CHANGELOG.md with implementation details