### PR TITLE
LCWEB-160 feat: Add custom message field to user invitation emails

### DIFF
--- a/src/components/admin/AdminUserManager.tsx
+++ b/src/components/admin/AdminUserManager.tsx
@@ -116,6 +116,7 @@ export default function AdminUserManager() {
   const [invitationSearchTerm, setInvitationSearchTerm] = useState('')
   const [invitationDialogOpen, setInvitationDialogOpen] = useState(false)
   const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteCustomMessage, setInviteCustomMessage] = useState('')
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null)
   const [availableLocations, setAvailableLocations] = useState<Location[]>([])
   const [invitationsLoading, setInvitationsLoading] = useState(false)
@@ -831,11 +832,13 @@ export default function AdminUserManager() {
         method: 'POST',
         body: JSON.stringify({
           invited_email: inviteEmail.trim(),
+          custom_message: inviteCustomMessage.trim() || undefined,
         }),
       })
 
       if (response.ok) {
         setInviteEmail('')
+        setInviteCustomMessage('')
         setSelectedLocationId(null)
         setInvitationDialogOpen(false)
         await alert({
@@ -1640,6 +1643,18 @@ export default function AdminUserManager() {
               </Select>
             </FormControl>
 
+            <TextField
+              label="Personal Message (Optional)"
+              multiline
+              rows={3}
+              value={inviteCustomMessage}
+              onChange={(e) => setInviteCustomMessage(e.target.value)}
+              fullWidth
+              sx={{ mb: 2 }}
+              placeholder="Add a personal message to include with the invitation..."
+              helperText="This message will be included in the invitation email to make it more personal"
+            />
+
             {/* Bulk invitation results */}
             {bulkInviteResults.length > 0 && (
               <Box sx={{ mt: 2 }}>
@@ -1667,6 +1682,7 @@ export default function AdminUserManager() {
               onClick={() => {
                 setInvitationDialogOpen(false)
                 setInviteEmail('')
+                setInviteCustomMessage('')
                 setBulkEmails('')
                 setSelectedLocationId(null)
                 setBulkInviteMode(false)

--- a/workers/email/index.ts
+++ b/workers/email/index.ts
@@ -223,7 +223,7 @@ This is an automated message from LibraryCard.
   }
 }
 
-export async function sendInvitationEmail(env: Env, email: string, locationName: string, token: string, invitedBy: string) {
+export async function sendInvitationEmail(env: Env, email: string, locationName: string, token: string, invitedBy: string, customMessage?: string) {
   // Removed sensitive debug logging
   if (!env.APP_URL) {
     throw new Error('APP_URL environment variable is required for invitation emails');
@@ -282,6 +282,12 @@ export async function sendInvitationEmail(env: Env, email: string, locationName:
                 <p style="font-size: 16px; margin-bottom: 20px;">
                   ${inviterName} has invited you to join the <strong>${locationName}</strong> library on LibraryCard.
                 </p>
+                ${customMessage ? `
+                <div style="background: #e9ecef; border-left: 4px solid #007bff; padding: 15px; margin: 20px 0; border-radius: 4px;">
+                  <p style="font-size: 16px; margin: 0; font-style: italic; color: #495057;">
+                    "${customMessage}"
+                  </p>
+                </div>` : ''}
                 <p style="font-size: 16px; margin-bottom: 30px;">
                   LibraryCard helps you organize and share book collections. Join to browse books and add your own to the shared library.
                 </p>

--- a/workers/invitations/index.ts
+++ b/workers/invitations/index.ts
@@ -15,7 +15,7 @@ export async function createLocationInvitation(request: Request, locationId: num
     });
   }
 
-  const { invited_email }: { invited_email: string } = await request.json();
+  const { invited_email, custom_message }: { invited_email: string; custom_message?: string } = await request.json();
 
   // Validate email format
   if (!invited_email || !invited_email.includes('@')) {
@@ -92,7 +92,7 @@ export async function createLocationInvitation(request: Request, locationId: num
   // Send invitation email
   try {
     console.log('DEBUG: About to call sendInvitationEmail for:', invited_email);
-    await sendInvitationEmail(env, invited_email, (location as any)?.name || 'a location', invitationToken, userId);
+    await sendInvitationEmail(env, invited_email, (location as any)?.name || 'a location', invitationToken, userId, custom_message);
     console.log('DEBUG: sendInvitationEmail completed for:', invited_email);
   } catch (emailError) {
     console.error('ERROR: Failed to send invitation email:', {


### PR DESCRIPTION
- Add optional textarea to AdminUserManager invitation dialog for personal messages
- Update backend API to accept and handle custom_message parameter
- Enhance email template with styled callout section for custom messages
- Include proper form state cleanup when dialog closes or invitation succeeds
- Custom message displays in attractive bordered callout with italic styling in emails

This allows inviters to add personal touches to invitation emails, making them more welcoming and personalized for new users joining library locations.