### PR TITLE
LCWEB-167 fix: Add cache invalidation after email verification

### DIFF
--- a/workers/auth-core/index.ts
+++ b/workers/auth-core/index.ts
@@ -397,6 +397,16 @@ export async function verifyEmail(request: Request, env: Env, corsHeaders: Recor
     SET email_verified = TRUE, email_verification_token = NULL, email_verification_expires = NULL, updated_at = datetime('now')
     WHERE id = ?
   `).bind(user.id).run();
+
+  // Invalidate admin caches since user verification status changed
+  try {
+    const { invalidateAllAdminAnalytics } = await import('../admin/cached');
+    await invalidateAllAdminAnalytics(env);
+    console.log('Invalidated admin cache after email verification');
+  } catch (cacheError) {
+    console.warn('Failed to invalidate admin cache after email verification:', cacheError);
+    // Don't fail verification if cache invalidation fails
+  }
   
   // Check if there are any pending invitations for this email
   const pendingInvitation = await env.DB.prepare(`


### PR DESCRIPTION
Fixes issue where admin user lists showed "unverified" status for users who had successfully completed email verification. Added invalidateAllAdminAnalytics() call to verifyEmail function to ensure admin interfaces reflect updated verification status immediately.

Changes:
- Added cache invalidation in workers/auth-core/index.ts after email verification
- Admin user lists will now correctly show "verified" status
- Follows existing pattern used throughout codebase for cache management