### PR TITLE
LCWEB-168 fix: Display user firstname in navigation instead of username

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { ThemeContextProvider } from '@/lib/ThemeContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import PerformanceTracker from '@/components/performance/PerformanceTracker'
 import inputEventDebug from '@/lib/inputEventDebug'
+import { UserDataProvider } from '@/contexts/UserDataContext'
 import { useState, useEffect } from 'react'
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -46,9 +47,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
         <ThemeContextProvider>
-          {children}
-          {/* Performance monitoring */}
-          <PerformanceTracker />
+          <UserDataProvider>
+            {children}
+            {/* Performance monitoring */}
+            <PerformanceTracker />
+          </UserDataProvider>
         </ThemeContextProvider>
       </QueryClientProvider>
     </SessionProvider>

--- a/src/components/layout/AppLayoutWithGlobalHeader.tsx
+++ b/src/components/layout/AppLayoutWithGlobalHeader.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { getApiBaseUrl } from '@/lib/apiConfig'
 import { authenticatedApiCall } from '@/lib/api'
 import { authenticatedFetch } from '@/lib/auth-utils'
+import { useUserData } from '@/contexts/UserDataContext'
 import { Container, Box } from '@mui/material'
 import Footer from './Footer'
 import GlobalHeader from './GlobalHeader'
@@ -21,78 +22,29 @@ export default function AppLayoutWithGlobalHeader({ children }: AppLayoutWithGlo
   const { data: session } = useSession()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const [userRole, setUserRole] = useState<string | null>(null)
-  const [userFirstName, setUserFirstName] = useState<string | null>(null)
-  const [userLocation, setUserLocation] = useState<string | null>(null)
-  const [userDataLoaded, setUserDataLoaded] = useState(false)
+  const { userRole, userFirstName, userLocation, userDataLoaded, loadUserData } = useUserData()
   const [helpModalOpen, setHelpModalOpen] = useState(false)
   const dataLoadedRef = useRef(false)
 
   useEffect(() => {
     if (session && !dataLoadedRef.current) {
       dataLoadedRef.current = true
-      
+
       // Check for invitation token from Google OAuth redirect
       const invitationToken = searchParams.get('invitation')
       if (invitationToken) {
         handleInvitationAcceptance(invitationToken)
         return
       }
-
-      // Load user data only once
-      loadUserData()
     }
   }, [session])
-  
+
   // Reset data loaded flag when session changes
   useEffect(() => {
     if (!session) {
       dataLoadedRef.current = false
-      setUserDataLoaded(false)
-      setUserRole(null)
-      setUserFirstName(null)
-      setUserLocation(null)
     }
   }, [session])
-
-  const loadUserData = async () => {
-    try {
-      // Fetch both user profile and locations in parallel
-      const [profileData, locations] = await Promise.all([
-        fetch(`${getApiBaseUrl()}/api/profile`, {
-          headers: {
-            'Authorization': `Bearer ${session?.user?.email}`,
-            'Content-Type': 'application/json',
-          },
-        }).then(res => res.json()),
-        fetch(`${getApiBaseUrl()}/api/locations`, {
-          headers: {
-            'Authorization': `Bearer ${session?.user?.email}`,
-            'Content-Type': 'application/json',
-          },
-        }).then(res => res.json())
-      ])
-
-      // Set user role and name from profile
-      if (profileData.user_role) {
-        setUserRole(profileData.user_role)
-      }
-      if (profileData.first_name) {
-        setUserFirstName(profileData.first_name)
-      }
-      
-      // Set user location from locations
-      if (locations && locations.length > 0) {
-        setUserLocation(locations[0].name)
-      }
-      
-      // Mark data as loaded
-      setUserDataLoaded(true)
-    } catch (err) {
-      console.error('Failed to fetch user data:', err)
-      setUserDataLoaded(true) // Still mark as loaded to prevent infinite loading
-    }
-  }
 
   const handleInvitationAcceptance = async (token: string) => {
     try {

--- a/src/components/marketing/layout/MarketingLayout.tsx
+++ b/src/components/marketing/layout/MarketingLayout.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import React from 'react'
+import { useUserData } from '@/contexts/UserDataContext'
 import GlobalHeader from '@/components/layout/GlobalHeader'
 import MarketingFooter from './MarketingFooter'
 
@@ -7,14 +10,21 @@ interface MarketingLayoutProps {
 }
 
 export default function MarketingLayout({ children }: MarketingLayoutProps) {
+  const { userRole, userFirstName } = useUserData()
+
   return (
-    <div className="marketing-page">
-      <div className="marketing-content">
-        <GlobalHeader />
-        <main>
-          {children}
-        </main>
-        <MarketingFooter />
+    <div>
+      <GlobalHeader
+        userRole={userRole}
+        userFirstName={userFirstName}
+      />
+      <div className="marketing-page">
+        <div className="marketing-content">
+          <main>
+            {children}
+          </main>
+          <MarketingFooter />
+        </div>
       </div>
     </div>
   )

--- a/src/contexts/UserDataContext.tsx
+++ b/src/contexts/UserDataContext.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import React, { createContext, useContext, useState, useEffect, useRef } from 'react'
+import { useSession } from 'next-auth/react'
+import { getApiBaseUrl } from '@/lib/apiConfig'
+
+interface UserData {
+  userRole: string | null
+  userFirstName: string | null
+  userLocation: string | null
+  userDataLoaded: boolean
+}
+
+interface UserDataContextType extends UserData {
+  loadUserData: () => Promise<void>
+}
+
+const UserDataContext = createContext<UserDataContextType | undefined>(undefined)
+
+export function UserDataProvider({ children }: { children: React.ReactNode }) {
+  const { data: session } = useSession()
+  const [userRole, setUserRole] = useState<string | null>(null)
+  const [userFirstName, setUserFirstName] = useState<string | null>(null)
+  const [userLocation, setUserLocation] = useState<string | null>(null)
+  const [userDataLoaded, setUserDataLoaded] = useState(false)
+  const dataLoadedRef = useRef(false)
+
+  const loadUserData = async () => {
+    if (!session) return
+
+    try {
+      // Fetch both user profile and locations in parallel
+      const [profileData, locations] = await Promise.all([
+        fetch(`${getApiBaseUrl()}/api/profile`, {
+          headers: {
+            'Authorization': `Bearer ${session?.user?.email}`,
+            'Content-Type': 'application/json',
+          },
+        }).then(res => res.json()),
+        fetch(`${getApiBaseUrl()}/api/locations`, {
+          headers: {
+            'Authorization': `Bearer ${session?.user?.email}`,
+            'Content-Type': 'application/json',
+          },
+        }).then(res => res.json())
+      ])
+
+      // Set user role and name from profile
+      if (profileData.user_role) {
+        setUserRole(profileData.user_role)
+      }
+      if (profileData.first_name) {
+        setUserFirstName(profileData.first_name)
+      }
+
+      // Set user location from locations
+      if (locations && locations.length > 0) {
+        setUserLocation(locations[0].name)
+      }
+
+      // Mark data as loaded
+      setUserDataLoaded(true)
+    } catch (err) {
+      console.error('Failed to fetch user data:', err)
+      setUserDataLoaded(true) // Still mark as loaded to prevent infinite loading
+    }
+  }
+
+  useEffect(() => {
+    if (session && !dataLoadedRef.current) {
+      dataLoadedRef.current = true
+      loadUserData()
+    }
+  }, [session])
+
+  // Reset data loaded flag when session changes
+  useEffect(() => {
+    if (!session) {
+      dataLoadedRef.current = false
+      setUserDataLoaded(false)
+      setUserRole(null)
+      setUserFirstName(null)
+      setUserLocation(null)
+    }
+  }, [session])
+
+  const contextValue: UserDataContextType = {
+    userRole,
+    userFirstName,
+    userLocation,
+    userDataLoaded,
+    loadUserData
+  }
+
+  return (
+    <UserDataContext.Provider value={contextValue}>
+      {children}
+    </UserDataContext.Provider>
+  )
+}
+
+export function useUserData() {
+  const context = useContext(UserDataContext)
+  if (context === undefined) {
+    throw new Error('useUserData must be used within a UserDataProvider')
+  }
+  return context
+}


### PR DESCRIPTION
Fixed two issues with Support page navigation:
1. MarketingLayout wasn't fetching user profile data, causing GlobalHeader to fall back to username
2. Navigation greeting flickered when switching between layouts due to separate data fetching

Changes:
- Created UserDataContext for centralized user data management
- Updated MarketingLayout to fetch and pass user profile data to GlobalHeader
- Moved GlobalHeader outside marketing CSS wrappers to fix positioning inconsistency
- Replaced duplicate user data logic in both layouts with shared context
- Eliminated navigation greeting flicker between different layout types

Now shows "Hello, [FirstName]!" consistently across all pages including Support.

🤖 Generated with [Claude Code](https://claude.ai/code)