### PR TITLE
LCWEB-178 fix: Fix card color contrast issues in marketing pages

### DIFF
--- a/src/styles/marketing/components/cards.css
+++ b/src/styles/marketing/components/cards.css
@@ -381,20 +381,3 @@
     font-size: var(--marketing-text-3xl);
   }
 }
-
-/* Dark mode support (future) */
-@media (prefers-color-scheme: dark) {
-  .marketing-card,
-  .marketing-pricing-card,
-  .marketing-feature-card,
-  .marketing-testimonial-card,
-  .marketing-stats-card,
-  .marketing-blog-card {
-    background: var(--marketing-gray-800);
-    border-color: var(--marketing-gray-700);
-  }
-  
-  .marketing-card-flat {
-    border-color: var(--marketing-gray-700);
-  }
-}

--- a/src/styles/marketing/variables.css
+++ b/src/styles/marketing/variables.css
@@ -134,3 +134,21 @@
   --marketing-screen-xl: 1280px;
   --marketing-screen-2xl: 1536px;
 }
+
+/* Dark Mode Variables */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Dark Mode Neutral Colors - Inverted for proper contrast */
+    --marketing-white: #1f2937;
+    --marketing-gray-50: #111827;
+    --marketing-gray-100: #1f2937;
+    --marketing-gray-200: #374151;
+    --marketing-gray-300: #4b5563;
+    --marketing-gray-400: #6b7280;
+    --marketing-gray-500: #9ca3af;
+    --marketing-gray-600: #d1d5db;
+    --marketing-gray-700: #e5e7eb;
+    --marketing-gray-800: #f3f4f6;
+    --marketing-gray-900: #ffffff;
+  }
+}


### PR DESCRIPTION
- Add proper dark mode CSS variables with inverted gray scale for correct contrast
- Remove problematic dark mode card overrides that caused dark text on dark backgrounds
- Ensure marketing cards now display with proper contrast in both light and dark themes
- Light theme: Light backgrounds with dark text (proper contrast)
- Dark theme: Dark backgrounds with light text (proper contrast)

Files changed:
- src/styles/marketing/variables.css: Added dark mode variable overrides
- src/styles/marketing/components/cards.css: Removed conflicting dark mode styles