### PR TITLE
LCWEB-181 feat: Add OpenGraph and Twitter Card meta tags for social m…

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -18,6 +18,28 @@ import Button from '@/components/marketing/ui/Button'
 export const metadata: Metadata = {
   title: 'About - LibraryCard',
   description: 'Learn about LibraryCard\'s mission to make library management accessible to every community. Founded to bridge the gap between personal tools and expensive institutional software.',
+  openGraph: {
+    title: 'About - LibraryCard',
+    description: 'Learn about LibraryCard\'s mission to make library management accessible to every community. Founded to bridge the gap between personal tools and expensive institutional software.',
+    url: 'https://librarycard.tim52.io/about',
+    siteName: 'LibraryCard',
+    images: [
+      {
+        url: 'https://librarycard.tim52.io/images/hero-bg.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'About LibraryCard - Community Library Management Platform',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About - LibraryCard',
+    description: 'Learn about LibraryCard\'s mission to make library management accessible to every community. Founded to bridge the gap between personal tools and expensive institutional software.',
+    images: ['https://librarycard.tim52.io/images/hero-bg.jpg'],
+  },
 }
 
 function AboutHeader() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -19,6 +19,28 @@ import ContactForm from '@/components/marketing/forms/ContactForm'
 export const metadata: Metadata = {
   title: 'Contact - LibraryCard',
   description: 'Get in touch with the LibraryCard beta team. We\'re here to help with questions about the beta program and community library management.',
+  openGraph: {
+    title: 'Contact - LibraryCard',
+    description: 'Get in touch with the LibraryCard beta team. We\'re here to help with questions about the beta program and community library management.',
+    url: 'https://librarycard.tim52.io/contact',
+    siteName: 'LibraryCard',
+    images: [
+      {
+        url: 'https://librarycard.tim52.io/images/hero-bg.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Contact LibraryCard - Community Library Management Platform',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact - LibraryCard',
+    description: 'Get in touch with the LibraryCard beta team. We\'re here to help with questions about the beta program and community library management.',
+    images: ['https://librarycard.tim52.io/images/hero-bg.jpg'],
+  },
 }
 
 function ContactHeader() {

--- a/src/app/features/page.tsx
+++ b/src/app/features/page.tsx
@@ -23,6 +23,28 @@ import Button from '@/components/marketing/ui/Button'
 export const metadata: Metadata = {
   title: 'Beta Features - LibraryCard',
   description: 'Explore LibraryCard beta features for community library management. ISBN scanning, multi-user access, location tracking, and more. Join our beta program today.',
+  openGraph: {
+    title: 'Beta Features - LibraryCard',
+    description: 'Explore LibraryCard beta features for community library management. ISBN scanning, multi-user access, location tracking, and more. Join our beta program today.',
+    url: 'https://librarycard.tim52.io/features',
+    siteName: 'LibraryCard',
+    images: [
+      {
+        url: 'https://librarycard.tim52.io/images/hero-bg.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'LibraryCard Beta Features - Community Library Management Platform',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Beta Features - LibraryCard',
+    description: 'Explore LibraryCard beta features for community library management. ISBN scanning, multi-user access, location tracking, and more. Join our beta program today.',
+    images: ['https://librarycard.tim52.io/images/hero-bg.jpg'],
+  },
 }
 
 function FeaturesHeader() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,28 @@ import ConditionalAppLayout from '@/components/layout/ConditionalAppLayout'
 export const metadata: Metadata = {
   title: 'LibraryCard - Community Library Management',
   description: 'Community-first library management platform. Bridge the gap between personal tools and institutional software. Perfect for apartments, retirement communities, and book clubs.',
+  openGraph: {
+    title: 'LibraryCard - Community Library Management',
+    description: 'Community-first library management platform. Bridge the gap between personal tools and institutional software. Perfect for apartments, retirement communities, and book clubs.',
+    url: 'https://librarycard.tim52.io',
+    siteName: 'LibraryCard',
+    images: [
+      {
+        url: 'https://librarycard.tim52.io/images/hero-bg.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'LibraryCard - Community Library Management Platform',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'LibraryCard - Community Library Management',
+    description: 'Community-first library management platform. Bridge the gap between personal tools and institutional software. Perfect for apartments, retirement communities, and book clubs.',
+    images: ['https://librarycard.tim52.io/images/hero-bg.jpg'],
+  },
 }
 
 export default function RootLayout({

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -9,6 +9,28 @@ import Button from '@/components/marketing/ui/Button'
 export const metadata: Metadata = {
   title: 'Join Beta - LibraryCard',
   description: 'Join the LibraryCard beta program and help us build the perfect community library management tool. Free access during development.',
+  openGraph: {
+    title: 'Join Beta - LibraryCard',
+    description: 'Join the LibraryCard beta program and help us build the perfect community library management tool. Free access during development.',
+    url: 'https://librarycard.tim52.io/pricing',
+    siteName: 'LibraryCard',
+    images: [
+      {
+        url: 'https://librarycard.tim52.io/images/hero-bg.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Join LibraryCard Beta - Community Library Management Platform',
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Join Beta - LibraryCard',
+    description: 'Join the LibraryCard beta program and help us build the perfect community library management tool. Free access during development.',
+    images: ['https://librarycard.tim52.io/images/hero-bg.jpg'],
+  },
 }
 
 function BetaHeader() {


### PR DESCRIPTION
…edia sharing

- Added comprehensive OpenGraph meta tags to root layout and all marketing pages
- Included og:title, og:description, og:url, og:image, og:siteName, og:locale, og:type
- Added Twitter Card meta tags with summary_large_image format
- Used hero-bg.jpg as default social sharing image (1200x630)
- Updated all URLs to use correct domain: librarycard.tim52.io
- Improves social media link previews on Facebook, Twitter, LinkedIn and other platforms