### PR TITLE
hotfix: Fix production API URL routing bug in domain configuration

### DIFF
--- a/src/lib/domainConfig.ts
+++ b/src/lib/domainConfig.ts
@@ -79,7 +79,7 @@ export function getDomainConfig(): DomainConfig {
     case 'production':
       return {
         domain: process.env.DOMAIN || 'librarycard.tim52.io',
-        apiSubdomain: process.env.API_SUBDOMAIN || 'api',
+        apiSubdomain: process.env.API_SUBDOMAIN, // Only use if explicitly set
         emailDomain: process.env.EMAIL_DOMAIN || 'tim52.io',
         environment: 'production'
       }


### PR DESCRIPTION
CRITICAL PRODUCTION BUG FIX - API calls were going to wrong domain causing complete application failure.

## Problem:
- Frontend requests going to https://api.librarycard.tim52.io (non-existent)
- Should be going to https://librarycard-api-production.tim-arnold.workers.dev
- NEXT_PUBLIC_API_URL correctly set but being overridden by faulty domain logic

## Root Cause:
- domainConfig.ts line 82 had: apiSubdomain: process.env.API_SUBDOMAIN || 'api'
- This defaulted to 'api' even when API_SUBDOMAIN wasn't set
- Caused subdomain construction logic to override NEXT_PUBLIC_API_URL

## Fix:
- Changed to: apiSubdomain: process.env.API_SUBDOMAIN
- Now only uses subdomain construction when API_SUBDOMAIN explicitly set
- Falls back to NEXT_PUBLIC_API_URL as intended

## Impact:
- Fixes: No books loading, email login failures, API errors
- Restores: Full application functionality in production
- OAuth worked because NextAuth bypasses this configuration

Immediate deployment required to restore production service.