### PR TITLE
feat: Add R2 and AI bindings to production Wrangler config

### DIFF
--- a/wrangler.prod.toml
+++ b/wrangler.prod.toml
@@ -36,6 +36,15 @@ database_id = "368ab7bc-fb42-4607-a4cf-761dc7795284"
 binding = "CACHE"
 id = "8f5a86fc82a64b10ba946d749f2dc8f4"
 
+# Production R2 Storage
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "librarycard-images-production"
+
+# Production AI
+[ai]
+binding = "AI"
+
 # ONLY production environment - no local/staging to prevent confusion
 [env.production]
 name = "librarycard-api-production"


### PR DESCRIPTION
- Add R2_BUCKET binding for librarycard-images-production bucket
- Add AI binding for Cloudflare AI integration
- Enables image storage and AI features in production environment