### PR TITLE
fix: Modify R2 and AI bindings to production Wrangler config

### DIFF
--- a/wrangler.prod.toml
+++ b/wrangler.prod.toml
@@ -36,15 +36,6 @@ database_id = "368ab7bc-fb42-4607-a4cf-761dc7795284"
 binding = "CACHE"
 id = "8f5a86fc82a64b10ba946d749f2dc8f4"
 
-# Production R2 Storage
-[[r2_buckets]]
-binding = "R2_BUCKET"
-bucket_name = "librarycard-images-production"
-
-# Production AI
-[ai]
-binding = "AI"
-
 # ONLY production environment - no local/staging to prevent confusion
 [env.production]
 name = "librarycard-api-production"
@@ -61,3 +52,10 @@ database_id = "368ab7bc-fb42-4607-a4cf-761dc7795284"
 [[env.production.kv_namespaces]]
 binding = "CACHE"
 id = "8f5a86fc82a64b10ba946d749f2dc8f4"
+
+[[env.production.r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "librarycard-images-production"
+
+[env.production.ai]
+binding = "AI"

--- a/wrangler.staging-new.toml
+++ b/wrangler.staging-new.toml
@@ -34,15 +34,6 @@ database_id = "4283d8af-c667-4673-8505-108f02b4609c"
 binding = "CACHE"
 id = "a7451e32dc8740efb83e3c0751ea3c08"
 
-# Staging R2 Storage - NEW ACCOUNT
-[[r2_buckets]]
-binding = "R2_BUCKET"
-bucket_name = "librarycard-images-staging"
-
-# Staging AI - NEW ACCOUNT
-[ai]
-binding = "AI"
-
 # ONLY staging environment - isolated account
 [env.staging]
 name = "librarycard-api-staging"


### PR DESCRIPTION
- Add R2_BUCKET binding for librarycard-images-production bucket
- Add AI binding for Cloudflare AI integration
- Enables image storage and AI features in production environment