### PR TITLE
LCWEB-194 fix: Update all notification badge colors to match theme co…

### DIFF
--- a/src/components/admin/AdminNotificationCenter.tsx
+++ b/src/components/admin/AdminNotificationCenter.tsx
@@ -193,7 +193,7 @@ export default function AdminNotificationCenter({ onDataChange }: AdminNotificat
             />
             <Tab
               label={
-                <Badge badgeContent={counts.pendingAppeals} color="error">
+                <Badge badgeContent={counts.pendingAppeals} color="primary">
                   Appeals
                 </Badge>
               }

--- a/src/components/layout/GlobalHeader.tsx
+++ b/src/components/layout/GlobalHeader.tsx
@@ -425,8 +425,8 @@ export default function GlobalHeader({ userRole, userFirstName }: GlobalHeaderPr
                     {item.key === 'admin' && totalAdminNotifications > 0 && (
                       <span
                         style={{
-                          backgroundColor: muiTheme.palette.error.main,
-                          color: muiTheme.palette.error.contrastText,
+                          backgroundColor: muiTheme.palette.primary.main,
+                          color: muiTheme.palette.primary.contrastText,
                           borderRadius: '50%',
                           width: '18px',
                           height: '18px',
@@ -711,7 +711,7 @@ export default function GlobalHeader({ userRole, userFirstName }: GlobalHeaderPr
                             position: 'absolute',
                             top: '-6px',
                             right: '-6px',
-                            backgroundColor: 'var(--marketing-error)',
+                            backgroundColor: 'var(--marketing-primary)',
                             color: 'var(--marketing-white)',
                             borderRadius: '50%',
                             width: '20px',
@@ -763,7 +763,7 @@ export default function GlobalHeader({ userRole, userFirstName }: GlobalHeaderPr
                                     position: 'absolute',
                                     top: '-6px',
                                     right: '-6px',
-                                    backgroundColor: 'var(--marketing-error)',
+                                    backgroundColor: 'var(--marketing-primary)',
                                     color: 'var(--marketing-white)',
                                     borderRadius: '50%',
                                     width: '16px',
@@ -1247,8 +1247,8 @@ export default function GlobalHeader({ userRole, userFirstName }: GlobalHeaderPr
                       {item.key === 'admin' && totalAdminNotifications > 0 && (
                         <span
                           style={{
-                            backgroundColor: muiTheme.palette.error.main,
-                            color: muiTheme.palette.error.contrastText,
+                            backgroundColor: muiTheme.palette.primary.main,
+                            color: muiTheme.palette.primary.contrastText,
                             borderRadius: '50%',
                             width: '20px',
                             height: '20px',


### PR DESCRIPTION
…nsistency

- Change Appeals badge from color="error" to color="primary" in AdminNotificationCenter
- Change Admin tab badge from error.main to primary.main in GlobalHeader (desktop)
- Change Admin tab badge from error.main to primary.main in GlobalHeader (mobile)
- Change Account button badge from marketing-error to marketing-primary in GlobalHeader
- Change Notifications menu item badge from marketing-error to marketing-primary in GlobalHeader

All notification badges now use consistent primary theme color instead of red error color. Matches the purple/blue badge pattern for visual consistency across the application.