### PR TITLE
LCWEB-208 fix: Prevent create location modal from auto-opening on tab…

### DIFF
--- a/src/components/admin/LocationManager.tsx
+++ b/src/components/admin/LocationManager.tsx
@@ -93,12 +93,12 @@ export default function LocationManager() {
   }, [selectedLocation, session])
 
   useEffect(() => {
-    if (locations.length === 0 && userRole === 'super_admin') {
+    if (locations.length === 0 && userRole === 'super_admin' && !loading) {
       setShowCreateForm(true)
     } else if (locations.length > 0 && !selectedLocation) {
       setSelectedLocation(locations[0])
     }
-  }, [locations, userRole])
+  }, [locations, userRole, selectedLocation, loading])
 
   const handleCreateLocation = async (formData: any) => {
     const newLocation = await createLocation(formData)


### PR DESCRIPTION
… load

Fixed bug where "Create Location" modal would open automatically when switching to admin > locations tab:
- Added !loading guard to prevent opening create form during initial data load
- Added selectedLocation and loading to useEffect dependency array to prevent stale closure issues
- Modal now only opens when locations.length === 0 AND user is super_admin AND loading is complete

Previously, the effect would run during loading when locations.length === 0 temporarily, triggering setShowCreateForm(true) even when locations existed.