### PR TITLE
Stop tracking next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn-error.log*
 
 # TypeScript
 *.tsbuildinfo
+next-env.d.ts
 
 # Backup and restore files
 /backups-staging/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
`next-env.d.ts` is auto-generated by Next.js on every `dev`/`build` run and was showing as perpetually modified after the Next.js 16 upgrade (the import path changed from `.next/types/` to `.next/dev/types/`).

- Added `next-env.d.ts` to `.gitignore`
- Removed it from git tracking via `git rm --cached`

The file still exists locally and TypeScript still uses it — git just stops caring about changes to it.