### PR TITLE
Fix book search 429 rate limiting — proxy through Cloudflare Worker with KV cache

### DIFF
--- a/docs/reference/CHANGELOG.md
+++ b/docs/reference/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents all completed features, fixes, and improvements to the LibraryCard project.
 
+## May 2026 - Book Search Rate Limit Fix
+
+### Fixed
+- **Google Books 429 rate limiting** — Book search no longer calls the Google Books API directly from the browser. Requests now proxy through the Cloudflare Worker (`/api/books/search`), which applies KV caching so repeated searches for the same query skip the Google API entirely. The endpoint is public (no auth required), matching the previous behaviour. This eliminates per-IP unauthenticated quota exhaustion that was causing 429 errors on the live site.
+
 ## March 2026 - GitHub Actions Documentation
 
 ### Infrastructure

--- a/src/components/book/BookSearch.tsx
+++ b/src/components/book/BookSearch.tsx
@@ -204,60 +204,48 @@ export default function BookSearch({
 
 
   const searchGoogleBooks = async (query: string) => {
-    const response = await fetch(
-      `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=40`
-    )
-    
+    const params = new URLSearchParams({ q: query, maxResults: '40' })
+    const response = await fetch(`${getApiBaseUrl()}/api/books/search?${params}`)
+
     if (response.ok) {
       const data = await response.json()
-      // Convert Google Books format to our enhanced format
       const convertedItems = (data.items || []).map((item: any) => ({
         id: item.id,
-        isbn: item.volumeInfo.industryIdentifiers?.find(
-          (id: any) => id.type === 'ISBN_13' || id.type === 'ISBN_10'
-        )?.identifier,
-        title: item.volumeInfo.title,
-        authors: item.volumeInfo.authors,
-        description: item.volumeInfo.description,
-        covers: item.volumeInfo.imageLinks ? {
-          thumbnail: ensureHttps(item.volumeInfo.imageLinks.thumbnail),
-          small: ensureHttps(item.volumeInfo.imageLinks.small),
-          medium: ensureHttps(item.volumeInfo.imageLinks.medium),
-          large: ensureHttps(item.volumeInfo.imageLinks.large),
-          extraLarge: ensureHttps(item.volumeInfo.imageLinks.extraLarge),
+        isbn: item.isbn,
+        title: item.title,
+        authors: item.authors,
+        description: item.description,
+        covers: item.imageLinks ? {
+          thumbnail: ensureHttps(item.imageLinks.thumbnail),
+          small: ensureHttps(item.imageLinks.small),
+          medium: ensureHttps(item.imageLinks.medium),
+          large: ensureHttps(item.imageLinks.large),
+          extraLarge: ensureHttps(item.imageLinks.extraLarge),
         } : undefined,
-        publishedDate: item.volumeInfo.publishedDate,
-        categories: item.volumeInfo.categories,
-        publisher: item.volumeInfo.publisher,
-        pageCount: item.volumeInfo.pageCount,
-        averageRating: item.volumeInfo.averageRating,
-        ratingsCount: item.volumeInfo.ratingsCount,
+        publishedDate: item.publishedDate,
+        categories: item.categories,
+        publisher: item.publisher,
+        pageCount: item.pageCount,
+        averageRating: item.averageRating,
+        ratingsCount: item.ratingsCount,
         source: 'google' as const,
         sourceDisplayName: 'Google Books',
-        // Keep legacy format for backward compatibility
-        volumeInfo: item.volumeInfo
       }))
-      
+
       onSearchResultsChange?.(convertedItems)
       onTotalResultsChange?.(data.totalItems || 0)
-      
-      // Only reset to 10 if parent doesn't have a specific displayedResults value
+
       if (parentDisplayedResults === undefined) {
         setDisplayedResults(10)
         onDisplayedResultsChange?.(10)
       }
-      
-      // Scroll to "Search Results" heading after results are loaded
-      // Use longer timeout to ensure DOM is fully rendered
+
       setTimeout(() => {
         if (searchResultsRef.current) {
-          console.log('Scrolling to Search Results (Google):', { element: searchResultsRef.current, offsetTop: searchResultsRef.current.offsetTop, currentScrollTop: window.scrollY })
-          searchResultsRef.current.scrollIntoView({ 
+          searchResultsRef.current.scrollIntoView({
             behavior: 'smooth',
             block: 'start'
           })
-        } else {
-          console.log('searchResultsRef.current is null (Google)')
         }
       }, 300)
     } else {

--- a/workers/books/google-cached.ts
+++ b/workers/books/google-cached.ts
@@ -1,6 +1,13 @@
 import { Env, GoogleBooksResponse } from '../types';
 import { CacheManager, CacheKeys, CacheTTL } from '../cache/kv';
 
+function googleBooksUrl(path: string, params: Record<string, string>, env: Env): string {
+  const url = new URL(`https://www.googleapis.com/books/v1/${path}`);
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  if (env.GOOGLE_BOOKS_API_KEY) url.searchParams.set('key', env.GOOGLE_BOOKS_API_KEY);
+  return url.toString();
+}
+
 // Utility function to ensure Google Books thumbnail URLs use HTTPS
 function ensureHttps(url: string | undefined): string | undefined {
   if (!url) return url
@@ -29,8 +36,8 @@ export async function getCachedGoogleBooksISBN(isbn: string, env: Env): Promise<
   
   // Fallback to Google Books API
   try {
-    const response = await fetch(`https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`);
-    
+    const response = await fetch(googleBooksUrl('volumes', { q: `isbn:${isbn}` }, env));
+
     if (!response.ok) {
       console.warn(`Google Books API error for ISBN ${isbn}: ${response.status}`);
       return null;
@@ -96,7 +103,7 @@ export async function getCachedGoogleBooksSearch(query: string, env: Env, maxRes
   // Fallback to Google Books API
   try {
     const response = await fetch(
-      `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=${maxResults}`
+      googleBooksUrl('volumes', { q: query, maxResults: String(maxResults) }, env)
     );
     
     if (!response.ok) {
@@ -168,7 +175,7 @@ export async function getCachedGoogleBooksVolume(volumeId: string, env: Env): Pr
   
   // Fallback to Google Books API
   try {
-    const response = await fetch(`https://www.googleapis.com/books/v1/volumes/${volumeId}`);
+    const response = await fetch(googleBooksUrl(`volumes/${volumeId}`, {}, env));
     
     if (!response.ok) {
       console.warn(`Google Books API volume error for ID ${volumeId}: ${response.status}`);
@@ -231,7 +238,7 @@ export async function getCachedBookEditions(title: string, author: string, env: 
   // Fallback to Google Books API
   try {
     const response = await fetch(
-      `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=20`
+      googleBooksUrl('volumes', { q: query, maxResults: '20' }, env)
     );
     
     if (!response.ok) {

--- a/workers/router.ts
+++ b/workers/router.ts
@@ -12,6 +12,7 @@ import { RateLimiter } from './auth/rate-limiter';
 import { withGlobalErrorHandling, ErrorCategory, createSecureErrorResponse } from './errors';
 import { getCachedGenreService } from './cache/genres';
 import { getWorkerFrontendUrl } from './utils/domainConfig';
+import { getCachedGoogleBooksSearch } from './books/google-cached';
 
 /**
  * Main Router - Orchestration layer for all endpoint routers
@@ -93,6 +94,24 @@ export class MainRouter {
         const cachedGenreService = getCachedGenreService(env);
         const genres = await cachedGenreService.getAllActiveGenres();
         return new Response(JSON.stringify(genres), {
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Public book search endpoint — proxies Google Books with KV caching, no auth needed
+      if (path === '/api/books/search' && method === 'GET') {
+        const query = url.searchParams.get('q');
+        const maxResults = Math.min(parseInt(url.searchParams.get('maxResults') || '40'), 40);
+
+        if (!query) {
+          return new Response(JSON.stringify({ error: 'q parameter is required' }), {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          });
+        }
+
+        const results = await getCachedGoogleBooksSearch(query, env, maxResults);
+        return new Response(JSON.stringify({ items: results || [], totalItems: results?.length || 0 }), {
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         });
       }

--- a/workers/types/index.ts
+++ b/workers/types/index.ts
@@ -25,6 +25,7 @@ export interface Env {
   GOOGLE_CLOUD_PROJECT_ID?: string;
   GOOGLE_APPLICATION_CREDENTIALS_JSON?: string;
   GOOGLE_API_KEY?: string;
+  GOOGLE_BOOKS_API_KEY?: string;
   // Cloudflare KV for caching
   CACHE?: KVNamespace;
   // Cloudflare R2 for image storage


### PR DESCRIPTION
## Summary
- Book search was calling the Google Books API directly from the browser (unauthenticated), exhausting the per-IP quota and causing 429 errors
- Search requests now proxy through the Cloudflare Worker at `/api/books/search`, a new public (no auth required) endpoint
- The worker applies KV caching — repeated searches for the same query skip Google entirely

## Test plan
- [ ] Run `npx wrangler dev` locally alongside `npm run dev`
- [ ] Search for a book title (e.g. "hobbit") — results should appear
- [ ] Search the same query again — should return instantly from KV cache (check worker logs)
- [ ] Verify searching without being logged in still returns results
- [ ] After deploying to production, confirm 429 errors no longer appear in the browser console when searching